### PR TITLE
Add Custom Point Type

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -44,7 +44,7 @@
 //! module. The [`extended`](extended/index.html) module has its own static `COLOR` and
 //! `COLOR_NAMES` variables.
 //!
-//! ## Random Colors
+//! # Random Colors
 //!
 //! You can also generate random colors. Here's an example:
 //!
@@ -68,7 +68,7 @@
 //! See the [examples directory on GitHub](https://github.com/sunjay/turtle/tree/master/examples)
 //! for more information.
 //!
-//! ## Creating a Color from Values
+//! # Creating a Color from Values
 //!
 //! Usually, you won't need to initialize a color this way since the above methods are quite
 //! convenient. However, in some situations it may be necessary to create a color with specific

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -162,16 +162,17 @@ impl Drawing {
     /// # use turtle::*;
     /// # fn main() {
     /// let mut turtle = Turtle::new();
-    /// assert_eq!(turtle.drawing().center(), [0.0, 0.0]);
-    /// turtle.drawing_mut().set_center([4.0, 3.0]);
-    /// assert_eq!(turtle.drawing().center(), [4.0, 3.0]);
+    /// assert_eq!(turtle.drawing().center(), Point {x: 0.0, y: 0.0});
+    /// turtle.drawing_mut().set_center(Point {x: 4.0, y: 3.0});
+    /// assert_eq!(turtle.drawing().center(), Point {x: 4.0, y: 3.0});
     /// # }
     /// ```
     pub fn center(&self) -> Point {
         self.window.borrow().fetch_drawing().center
     }
 
-    /// Sets the center of the drawing to the given point
+    /// Sets the center of the drawing to the given point. See the [`Point` struct](struct.Point.html)
+    /// documentation for more information.
     ///
     /// The center represents the offset from the center of the viewport at which to draw the
     /// drawing. The default center is (0, 0) which means that the drawing is centered at the
@@ -208,8 +209,9 @@ impl Drawing {
     /// Once you click on the window:
     ///
     /// ![turtle center offset](https://github.com/sunjay/turtle/raw/gh-pages/assets/images/docs/circle_offset_center.png)
-    pub fn set_center(&mut self, center: Point) {
-        if !center[0].is_finite() || !center[1].is_finite() {
+    pub fn set_center<P: Into<Point>>(&mut self, center: P) {
+        let center = center.into();
+        if !center.is_finite() {
             return;
         }
         self.window.borrow_mut().with_drawing_mut(|drawing| drawing.center = center);

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -163,7 +163,7 @@ impl Drawing {
     /// # fn main() {
     /// let mut turtle = Turtle::new();
     /// assert_eq!(turtle.drawing().center(), Point {x: 0.0, y: 0.0});
-    /// turtle.drawing_mut().set_center(Point {x: 4.0, y: 3.0});
+    /// turtle.drawing_mut().set_center([4.0, 3.0]);
     /// assert_eq!(turtle.drawing().center(), Point {x: 4.0, y: 3.0});
     /// # }
     /// ```

--- a/src/event.rs
+++ b/src/event.rs
@@ -94,8 +94,8 @@ pub(crate) fn from_piston_event<F>(event: &PistonEvent, to_local_coords: F) -> O
         },
         Input::Move(motion) => match motion {
             Motion::MouseCursor(x, y) => {
-                let local = to_local_coords([x, y]);
-                MouseMove {x: local[0], y: local[1]}
+                let local = to_local_coords(Point {x, y});
+                MouseMove {x: local.x, y: local.y}
             },
             // Ignored in favor of MouseCursor
             Motion::MouseRelative(..) => return None,

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -22,11 +22,17 @@ pub trait ConvertScreenCoordinates {
 
 impl ConvertScreenCoordinates for Point {
     fn to_screen_coords(self, center: Self) -> Self {
-        [center[0] + self[0], center[1] - self[1]]
+        Point {
+            x: center.x + self.x,
+            y: center.y - self.y,
+        }
     }
 
     fn to_local_coords(self, center: Self) -> Self {
-        [self[0] - center[0], center[1] - self[1]]
+        Point {
+            x: self.x - center.x,
+            y: center.y - self.y,
+        }
     }
 }
 
@@ -50,10 +56,10 @@ mod tests {
 
     #[test]
     fn to_screen_coords() {
-        let center: Point = [300.0, 400.0];
+        let center = Point {x: 300.0, y: 400.0};
 
-        let point: Point = [20.0, 30.0];
-        assert_eq!(point.to_screen_coords(center), [320.0, 370.0]);
-        assert_eq!(point.to_local_coords(center), [-280.0, 370.0]);
+        let point = Point {x: 20.0, y: 30.0};
+        assert_eq!(point.to_screen_coords(center), Point {x: 320.0, y: 370.0});
+        assert_eq!(point.to_local_coords(center), Point {x: -280.0, y: 370.0});
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ mod app;
 mod turtle;
 mod drawing;
 mod speed;
+mod point;
 mod radians;
 mod animation;
 mod extensions;
@@ -66,7 +67,8 @@ pub mod event;
 pub mod rand;
 
 pub use server::start;
-pub use turtle::{Turtle, Point, Distance, Angle};
+pub use point::Point;
+pub use turtle::{Turtle, Distance, Angle};
 pub use drawing::{Drawing, Size};
 pub use speed::{Speed};
 pub use color::{Color};

--- a/src/point.rs
+++ b/src/point.rs
@@ -132,7 +132,7 @@ impl Point {
     ///
     /// For our "cartesian" coordinate system, this is always (0.0, 0.0)
     pub fn origin() -> Self {
-        Point {x: 0.0, y: 0.0}
+        Self {x: 0.0, y: 0.0}
     }
 
     /// Returns true if both x and y are finite (neither infinite nor `NaN`).
@@ -154,13 +154,13 @@ impl Point {
 
     /// Computes the absolute value of x and y and returns a new `Point`
     pub fn abs(self) -> Self {
-        Point {x: self.x.abs(), y: self.y.abs()}
+        Self {x: self.x.abs(), y: self.y.abs()}
     }
 
     /// Returns a new `Point` with x and y set to the nearest integer to each of their values.
     /// Rounds half-way cases away from 0.0.
     pub fn round(self) -> Self {
-        Point {x: self.x.round(), y: self.y.round()}
+        Self {x: self.x.round(), y: self.y.round()}
     }
 
     /// Returns the square of the length of this point.
@@ -185,13 +185,13 @@ impl Point {
 
 impl From<(f64, f64)> for Point {
     fn from(pt: (f64, f64)) -> Self {
-        Point {x: pt.0, y: pt.1}
+        Self {x: pt.0, y: pt.1}
     }
 }
 
 impl From<[f64; 2]> for Point {
     fn from(pt: [f64; 2]) -> Self {
-        Point {x: pt[0], y: pt[1]}
+        Self {x: pt[0], y: pt[1]}
     }
 }
 
@@ -202,10 +202,10 @@ impl From<Point> for [f64; 2] {
 }
 
 impl Add for Point {
-    type Output = Point;
+    type Output = Self;
 
     fn add(self, other: Self) -> Self::Output {
-        Point {
+        Self {
             x: self.x + other.x,
             y: self.y + other.y,
         }
@@ -213,10 +213,10 @@ impl Add for Point {
 }
 
 impl Sub for Point {
-    type Output = Point;
+    type Output = Self;
 
     fn sub(self, other: Self) -> Self::Output {
-        Point {
+        Self {
             x: self.x - other.x,
             y: self.y - other.y,
         }
@@ -224,10 +224,10 @@ impl Sub for Point {
 }
 
 impl Mul<f64> for Point {
-    type Output = Point;
+    type Output = Self;
 
     fn mul(self, other: f64) -> Self::Output {
-        Point {
+        Self {
             x: self.x * other,
             y: self.y * other,
         }
@@ -235,10 +235,10 @@ impl Mul<f64> for Point {
 }
 
 impl Div<f64> for Point {
-    type Output = Point;
+    type Output = Self;
 
     fn div(self, other: f64) -> Self::Output {
-        Point {
+        Self {
             x: self.x / other,
             y: self.y / other,
         }

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,5 +1,6 @@
 use std::ops::{Add, Sub, Mul, Div, Index, IndexMut};
 
+use rand::{Rng, Rand, RandomRange};
 use interpolation::Spatial;
 
 /// A point in 2D space
@@ -116,6 +117,22 @@ use interpolation::Spatial;
 /// # }
 /// ```
 ///
+/// # Generating Random Points
+///
+/// ```rust
+/// # extern crate turtle;
+/// # use turtle::{Point, random};
+/// # fn main() {
+/// let pt: Point = random();
+/// assert!(pt.x >= 0.0 && pt.x < 1.0);
+/// assert!(pt.y >= 0.0 && pt.y < 1.0);
+/// # }
+/// ```
+///
+/// See the documentation for the [`rand`](rand/index.html) module and the section
+/// [Generating Random Values in a Range](rand/index.html#generating-random-values-in-a-range)
+/// for more information.
+///
 /// [`Turtle::go_to()`]: struct.Turtle.html#method.go_to
 /// [`Turtle::turn_towards()`]: struct.Turtle.html#method.turn_towards
 /// [`Drawing::set_center()`]: struct.Drawing.html#method.set_center
@@ -161,6 +178,42 @@ impl Point {
     /// Rounds half-way cases away from 0.0.
     pub fn round(self) -> Self {
         Self {x: self.x.round(), y: self.y.round()}
+    }
+
+    /// Returns the minimum x and y coordinates of the two points
+    ///
+    /// ```rust
+    /// # extern crate turtle;
+    /// # use turtle::Point;
+    /// # fn main() {
+    /// let p1 = Point {x: 100.0, y: 203.18};
+    /// let p2 = Point {x: 3.0, y: 1029.677};
+    /// assert_eq!(p1.min(p2), Point {x: 3.0, y: 203.18});
+    /// # }
+    /// ```
+    pub fn min(self, other: Self) -> Self {
+        Self {
+            x: self.x.min(other.x),
+            y: self.y.min(other.y),
+        }
+    }
+
+    /// Returns the maximum x and y coordinates of the two points
+    ///
+    /// ```rust
+    /// # extern crate turtle;
+    /// # use turtle::Point;
+    /// # fn main() {
+    /// let p1 = Point {x: 100.0, y: 203.18};
+    /// let p2 = Point {x: 3.0, y: 1029.677};
+    /// assert_eq!(p1.max(p2), Point {x: 100.0, y: 1029.677});
+    /// # }
+    /// ```
+    pub fn max(self, other: Self) -> Self {
+        Self {
+            x: self.x.max(other.x),
+            y: self.y.max(other.y),
+        }
     }
 
     /// Returns the square of the length of this point.
@@ -283,5 +336,26 @@ impl Spatial for Point {
     #[inline(always)]
     fn scale(&self, scalar: &Self::Scalar) -> Self {
         *self * *scalar
+    }
+}
+
+impl Rand for Point {
+    fn rand<R: Rng>(rng: &mut R) -> Self {
+        Self {
+            x: rng.gen(),
+            y: rng.gen(),
+        }
+    }
+}
+
+impl RandomRange for Point {
+    fn random_range<R: Rng>(rng: &mut R, p1: Self, p2: Self) -> Self {
+        let min = p1.min(p2);
+        let max = p1.max(p2);
+
+        Point {
+            x: RandomRange::random_range(rng, min.x, max.x),
+            y: RandomRange::random_range(rng, min.y, max.y),
+        }
     }
 }

--- a/src/point.rs
+++ b/src/point.rs
@@ -140,6 +140,28 @@ impl Div<f64> for Point {
     }
 }
 
+impl Index<usize> for Point {
+    type Output = f64;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        match index {
+            0 => &self.x,
+            1 => &self.y,
+            _ => panic!("Invalid coordinate for Point: {}", index),
+        }
+    }
+}
+
+impl IndexMut<usize> for Point {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        match index {
+            0 => &mut self.x,
+            1 => &mut self.y,
+            _ => panic!("Invalid coordinate for Point: {}", index),
+        }
+    }
+}
+
 impl Spatial for Point {
     type Scalar = f64;
 

--- a/src/point.rs
+++ b/src/point.rs
@@ -4,21 +4,126 @@ use interpolation::Spatial;
 
 /// A point in 2D space
 ///
+/// # Creating a Point
+///
+/// Methods like [`Turtle::go_to()`], [`Turtle::turn_towards()`] and [`Drawing::set_center()`]
+/// all support any type that can be converted into `Point`. That means that you can pass the
+/// same value into those methods in several different ways depending on what you prefer:
+///
+/// ```rust
+/// # extern crate turtle;
+/// # use turtle::Turtle;
+/// # fn main() {
+/// # let mut turtle = Turtle::new();
+/// // These are equivalent
+/// turtle.go_to([100.0, 40.0]);
+/// turtle.go_to((100.0, 40.0));
+/// // This is equivalent too, but the above examples are easier to type
+/// use turtle::Point;
+/// turtle.go_to(Point {x: 100.0, y: 40.0});
+/// # }
+/// ```
+///
+/// Each of these different styles works because the methods call
+/// [`.into()`](https://doc.rust-lang.org/std/convert/trait.Into.html) internally.
+///
 /// ```rust
 /// # extern crate turtle;
 /// # use turtle::Point;
 /// # fn main() {
-/// let p = Point {x: 100., y: 120.};
-/// // get x coordinate
-/// let x = p.x;
-/// assert_eq!(x, 100.);
-/// // get y coordinate
-/// let y = p.y;
-/// assert_eq!(y, 120.);
+/// assert_eq!(Point {x: 100.0, y: 40.0}, [100.0, 40.0].into());
+/// assert_eq!(Point {x: 100.0, y: 40.0}, (100.0, 40.0).into());
 /// # }
+/// ```
+///
+/// Notice that we need to convert the right side using `into()` before it can be compared
+/// in `assert_eq!()`.
+///
+/// ```rust,compile_fail,E0308
+/// # extern crate turtle;
+/// # use turtle::Point;
+/// # fn main() {
+/// // This will not compile
+/// assert_eq!(Point {x: 100.0, y: 40.0}, [100.0, 40.0]);
+/// assert_eq!(Point {x: 100.0, y: 40.0}, (100.0, 40.0));
+/// # }
+/// ```
+///
+/// # Manipulating Points
+///
+/// You can add or subtract points and multiply or divide points by scalar (f64) values. There
+/// are a variety of [method functions](struct.Point.html#methods) described in the
+/// documentation below that provide even more operations.
+///
+/// ```rust
+/// # extern crate turtle;
+/// # use turtle::Point;
+/// # fn main() {
+/// # let a = 320.0; let b = 400.0; let c = 70.0; let d = 95.0;
+/// // Let's say you have two points with f64 values a, b, c, and d
+/// let pt = Point {x: a, y: b};
+/// let pt2 = Point {x: c, y: d};
+/// assert_eq!(pt + pt2, Point {x: a + c, y: b + d});
+/// assert_eq!(pt - pt2, Point {x: a - c, y: b - d});
+/// assert_eq!(pt * 2.0, Point {x: a * 2.0, y: b * 2.0});
+/// assert_eq!(pt2 / 5.0, Point {x: c / 5.0, y: d / 5.0});
+/// assert_eq!(pt2 * 2.0 - pt, Point {x: c * 2.0 - a, y: d * 2.0 - b});
+/// # }
+/// ```
+///
+/// # Accessing Point Components
+///
+/// `Point` supports either using the `x` and `y` fields to access its components or using
+/// indexing if you prefer that style.
+///
+/// ```rust
+/// # extern crate turtle;
+/// # use turtle::Point;
+/// # fn main() {
+/// let p = Point {x: 100.0, y: 120.0};
+///
+/// // Get x coordinate
+/// let x = p.x;
+/// assert_eq!(x, 100.0);
+/// assert_eq!(p[0], x);
+///
+/// // Get y coordinate
+/// let y = p.y;
+/// assert_eq!(y, 120.0);
+/// assert_eq!(p[1], y);
+///
+/// // With pattern matching
+/// let Point {x, y} = p;
+/// assert_eq!(x, 100.0);
+/// assert_eq!(y, 120.0);
+///
+/// // Modifying x and y
+/// let mut pt: Point = [240.0, 430.0].into();
+/// # assert_eq!(pt.x, 240.0);
+/// # assert_eq!(pt.y, 430.0);
+/// pt.x = 73.0;
+/// pt.y = 89.0;
+/// assert_eq!(pt.x, 73.0);
+/// assert_eq!(pt.y, 89.0);
+/// // Using indexing
+/// let mut pt2: Point = [100.0, 200.0].into();
+/// # assert_eq!(pt2.x, 100.0);
+/// # assert_eq!(pt2.y, 200.0);
+/// pt2[0] = pt.x;
+/// pt2[1] = pt.y;
+/// assert_eq!(pt2.x, 73.0);
+/// assert_eq!(pt2.y, 89.0);
+/// # }
+/// ```
+///
+/// [`Turtle::go_to()`]: struct.Turtle.html#method.go_to
+/// [`Turtle::turn_towards()`]: struct.Turtle.html#method.turn_towards
+/// [`Drawing::set_center()`]: struct.Drawing.html#method.set_center
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct Point {
+    /// The x-coordinate of the Point
     pub x: f64,
+    /// The y-coordinate of the Point
     pub y: f64,
 }
 
@@ -60,19 +165,19 @@ impl Point {
 
     /// Returns the square of the length of this point.
     ///
-    /// The length of a point is defined as sqrt(x^2 + y^2)
+    /// The length of a point is defined as `sqrt(x^2 + y^2)`
     pub fn square_len(self) -> f64 {
         self.x.powi(2) + self.y.powi(2)
     }
 
     /// Returns the length of this point.
     ///
-    /// The length of a point is defined as sqrt(x^2 + y^2)
+    /// The length of a point is defined as `sqrt(x^2 + y^2)`
     pub fn len(self) -> f64 {
         self.square_len().sqrt()
     }
 
-    /// Computes the four quadrant arctangent of self.y and self.x.
+    /// Computes the four quadrant arctangent of `self.y` and `self.x`.
     pub fn atan2(self) -> f64 {
         self.y.atan2(self.x)
     }

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,0 +1,160 @@
+use std::ops::{Add, Sub, Mul, Div, Index, IndexMut};
+
+use interpolation::Spatial;
+
+/// A point in 2D space
+///
+/// ```rust
+/// # extern crate turtle;
+/// # use turtle::Point;
+/// # fn main() {
+/// let p = Point {x: 100., y: 120.};
+/// // get x coordinate
+/// let x = p.x;
+/// assert_eq!(x, 100.);
+/// // get y coordinate
+/// let y = p.y;
+/// assert_eq!(y, 120.);
+/// # }
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+}
+
+impl Point {
+    /// Returns a Point that represents the origin of the coordinate system.
+    ///
+    /// For our "cartesian" coordinate system, this is always (0.0, 0.0)
+    pub fn origin() -> Self {
+        Point {x: 0.0, y: 0.0}
+    }
+
+    /// Returns true if both x and y are finite (neither infinite nor `NaN`).
+    pub fn is_finite(self) -> bool {
+        self.x.is_finite() && self.y.is_finite()
+    }
+
+    /// Returns true if both x and y are neither zero, infinite,
+    /// [subnormal](https://en.wikipedia.org/wiki/Denormal_number), or `NaN`.
+    pub fn is_normal(self) -> bool {
+        self.x.is_normal() && self.y.is_normal()
+    }
+
+    /// Returns true if both x and y are either zero, infinite,
+    /// [subnormal](https://en.wikipedia.org/wiki/Denormal_number), or `NaN`.
+    pub fn is_not_normal(self) -> bool {
+        !self.x.is_normal() && !self.y.is_normal()
+    }
+
+    /// Computes the absolute value of x and y and returns a new `Point`
+    pub fn abs(self) -> Self {
+        Point {x: self.x.abs(), y: self.y.abs()}
+    }
+
+    /// Returns a new `Point` with x and y set to the nearest integer to each of their values.
+    /// Rounds half-way cases away from 0.0.
+    pub fn round(self) -> Self {
+        Point {x: self.x.round(), y: self.y.round()}
+    }
+
+    /// Returns the square of the length of this point.
+    ///
+    /// The length of a point is defined as sqrt(x^2 + y^2)
+    pub fn square_len(self) -> f64 {
+        self.x.powi(2) + self.y.powi(2)
+    }
+
+    /// Returns the length of this point.
+    ///
+    /// The length of a point is defined as sqrt(x^2 + y^2)
+    pub fn len(self) -> f64 {
+        self.square_len().sqrt()
+    }
+
+    /// Computes the four quadrant arctangent of self.y and self.x.
+    pub fn atan2(self) -> f64 {
+        self.y.atan2(self.x)
+    }
+}
+
+impl From<(f64, f64)> for Point {
+    fn from(pt: (f64, f64)) -> Self {
+        Point {x: pt.0, y: pt.1}
+    }
+}
+
+impl From<[f64; 2]> for Point {
+    fn from(pt: [f64; 2]) -> Self {
+        Point {x: pt[0], y: pt[1]}
+    }
+}
+
+impl From<Point> for [f64; 2] {
+    fn from(pt: Point) -> Self {
+        [pt.x, pt.y]
+    }
+}
+
+impl Add for Point {
+    type Output = Point;
+
+    fn add(self, other: Self) -> Self::Output {
+        Point {
+            x: self.x + other.x,
+            y: self.y + other.y,
+        }
+    }
+}
+
+impl Sub for Point {
+    type Output = Point;
+
+    fn sub(self, other: Self) -> Self::Output {
+        Point {
+            x: self.x - other.x,
+            y: self.y - other.y,
+        }
+    }
+}
+
+impl Mul<f64> for Point {
+    type Output = Point;
+
+    fn mul(self, other: f64) -> Self::Output {
+        Point {
+            x: self.x * other,
+            y: self.y * other,
+        }
+    }
+}
+
+impl Div<f64> for Point {
+    type Output = Point;
+
+    fn div(self, other: f64) -> Self::Output {
+        Point {
+            x: self.x / other,
+            y: self.y / other,
+        }
+    }
+}
+
+impl Spatial for Point {
+    type Scalar = f64;
+
+    #[inline(always)]
+    fn add(&self, other: &Self) -> Self {
+        *self + *other
+    }
+
+    #[inline(always)]
+    fn sub(&self, other: &Self) -> Self {
+        *self - *other
+    }
+
+    #[inline(always)]
+    fn scale(&self, scalar: &Self::Scalar) -> Self {
+        *self * *scalar
+    }
+}

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -88,7 +88,7 @@
 //! # }
 //! ```
 //!
-//! # More Functions for Generating Random Values
+//! # Generating Random Values in a Range
 //!
 //! The [`random_range()`] function allows you to generate values in a given range. You provide
 //! a lower bound and an upper bound. The number generated will be greater than or equal to the
@@ -110,7 +110,7 @@
 //! # }
 //! ```
 //!
-//! ## How can one function generate so many different return types?
+//! # How can one function generate so many different return types?
 //!
 //! Knowing how [`random()`] works is **not required** in order to be able to use it. That being said,
 //! it is an excellent example of combing the concepts of "generics" and "traits". If you are not
@@ -174,7 +174,7 @@
 //! This generates a random speed using the implementation of [`Rand`] for the [`Speed`] type in this
 //! crate.
 //!
-//! ### The Orphan Rule
+//! # The Orphan Rule
 //! Not all of the implementations of [`Rand`] for the types above are implemented in this
 //! crate. There is a rule known as the [orphan rule](https://doc.rust-lang.org/book/second-edition/ch10-02-traits.html#implementing-a-trait-on-a-type)
 //! which prevents anyone from implementing a trait on a type that they do not define. That is why

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -125,7 +125,10 @@ impl Renderer {
                 let view = c.get_view_size();
                 let width = view[0] as f64;
                 let height = view[1] as f64;
-                center = state.drawing().center.to_screen_coords([width * 0.5, height * 0.5]);
+                center = state.drawing().center.to_screen_coords(Point {
+                    x: width * 0.5,
+                    y: height * 0.5,
+                });
 
                 // We clone the relevant state before rendering so that the rendering thread
                 // doesn't need to keep locking, waiting or making the main thread wait
@@ -239,7 +242,7 @@ impl Renderer {
         let end = end.to_screen_coords(center);
 
         line(color.into(), thickness,
-            [start[0], start[1], end[0], end[1]],
+            [start.x, start.y, end.x, end.y],
             c.transform, g);
     }
 
@@ -267,7 +270,7 @@ impl Renderer {
         // See the commit before this comment was added for the approach that would have required
         // branching in every iteration of the loop where render_polygon is called over and over
         // again.
-        let verts = verts.map(|p| p.to_screen_coords(center)).collect::<Vec<_>>();
+        let verts = verts.map(|p| p.to_screen_coords(center).into()).collect::<Vec<_>>();
         polygon(fill_color.into(), &verts, c.transform, g);
     }
 
@@ -282,8 +285,8 @@ impl Renderer {
 
         let cos = heading.cos();
         let sin = heading.sin();
-        let turtle_x = position[0];
-        let turtle_y = position[1];
+        let turtle_x = position.x;
+        let turtle_y = position.y;
         let shell: Vec<_> = [
             [0., 15.],
             [10., 0.],
@@ -292,7 +295,7 @@ impl Renderer {
             // Rotate each point by the heading and add the current turtle position
             let x = cos * pt[0] - sin * pt[1] + turtle_x;
             let y = sin * pt[0] + cos * pt[1] + turtle_y;
-            [x, y].to_screen_coords(center)
+            Point {x, y}.to_screen_coords(center).into()
         }).collect();
 
         // Draw the turtle shell with its background first, then its border
@@ -302,8 +305,8 @@ impl Renderer {
             let end = shell[(i + 1) % shell.len()];
 
             line(color::BLACK.into(), 1.,
-            [start[0], start[1], end[0], end[1]],
-            c.transform, g);
+                [start[0], start[1], end[0], end[1]],
+                c.transform, g);
         }
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -46,7 +46,7 @@ impl Default for TurtleState {
         Self {
             pen: Pen::default(),
             fill_color: color::BLACK,
-            position: [0.0, 0.0],
+            position: Point::origin(),
             heading: Radians::from_degrees_value(90.0),
             speed: Speed::Five,
             visible: true,
@@ -70,7 +70,7 @@ impl Default for DrawingState {
         Self {
             title: "Turtle".to_owned(),
             background: color::WHITE,
-            center: [0.0, 0.0],
+            center: Point::origin(),
             width: 800,
             height: 600,
             maximized: false,

--- a/src/turtle.rs
+++ b/src/turtle.rs
@@ -319,14 +319,14 @@ impl Turtle {
     ///
     /// Anything else will cause the program to `panic!` at runtime.
     ///
-    /// ## Moving Instantly
+    /// # Moving Instantly
     ///
     /// A speed of zero (`Speed::Instant`) results in no animation. The turtle moves instantly
     /// and turns instantly. This is very useful for moving the turtle from its "home" position
     /// before you start drawing. By setting the speed to instant, you don't have to wait for
     /// the turtle to move into position.
     ///
-    /// ## Learning About Conversion Traits
+    /// # Learning About Conversion Traits
     ///
     /// Using this method is an excellent way to learn about conversion
     /// traits `From` and `Into`. This method takes a *generic type* as its speed parameter. That type

--- a/src/turtle_window.rs
+++ b/src/turtle_window.rs
@@ -1,8 +1,6 @@
 use std::time::Instant;
 use std::cell::RefCell;
 
-use piston_window::math;
-
 use server;
 use renderer_process::RendererProcess;
 use animation::{Animation, MoveAnimation, RotateAnimation, AnimationStatus};
@@ -96,7 +94,7 @@ impl TurtleWindow {
     pub fn go_to(&mut self, end: Point) {
         let TurtleState {position: start, speed, pen, ..} = self.fetch_turtle();
 
-        let distance = math::square_len(math::sub(start, end)).sqrt();
+        let distance = (end - start).len();
         if !distance.is_normal() {
             return;
         }
@@ -122,9 +120,11 @@ impl TurtleWindow {
         }
 
         let TurtleState {position: start, speed, heading, pen, ..} = self.fetch_turtle();
-        let x = distance * heading.cos();
-        let y = distance * heading.sin();
-        let end = math::add(start, [x, y]);
+        let movement = Point {
+            x: distance * heading.cos(),
+            y: distance * heading.sin(),
+        };
+        let end = start + movement;
 
         let speed = speed.to_absolute(); // px per second
         // We take the absolute value because the time is always positive, even if distance is negative


### PR DESCRIPTION
Fixes #18 

This is our own custom point type. We aren't using a properly linear algebra vector crate for this because:

* we want to keep the core of the turtle crate small (few dependencies)
* we want to be able to control our own type and add/change its methods as we see fit
* we want something that meets our standards of documentation and can grow with this crate