### PR TITLE
New Speed Representation

### DIFF
--- a/examples/dragon.rs
+++ b/examples/dragon.rs
@@ -49,7 +49,7 @@ fn main() {
     turtle.right(90.);
     turtle.forward(110.);
     turtle.pen_down();
-    turtle.set_speed(10);
+    turtle.set_speed("faster");
 
     dragon(&mut turtle, -90., 11, 0., 255.);
 
@@ -74,7 +74,7 @@ fn dragon(
     if num_folds == 0 {
         // mapping a color number 0-255 to an rgb gradient.
         turtle.set_pen_color(Color {
-            red: (color_mid - 128.).abs() * 2.,
+            red: ((color_mid - 128.).abs() * 2.).floor(),
             green: color_mid,
             blue: 160.,
             alpha: 1.,

--- a/examples/draw_turtle.rs
+++ b/examples/draw_turtle.rs
@@ -15,11 +15,13 @@ const EYE_COLOR: Color = color::BLACK;
 
 fn main() {
     let mut turtle = Turtle::new();
+    turtle.drawing_mut().set_size([250, 250]);
+
     turtle.set_speed(8);
 
     turtle.pen_up();
-    turtle.set_x(-280.0);
-    turtle.set_y(-90.0);
+    turtle.set_x(-70.0);
+    turtle.set_y(-20.0);
 
     draw_shell(&mut turtle);
 

--- a/examples/maze/main.rs
+++ b/examples/maze/main.rs
@@ -22,7 +22,7 @@ fn main() {
     let maze = Maze::generate();
 
     let mut turtle = Turtle::new();
-    turtle.set_speed(8);
+    turtle.set_speed(20);
     turtle.drawing_mut().set_background_color("#BDBDBD");
     turtle.set_pen_color("#03A9F4");
     turtle.set_pen_size(2.0);
@@ -71,7 +71,7 @@ fn main() {
     turtle.left(90.0);
     turtle.pen_down();
 
-    turtle.set_speed(5);
+    turtle.set_speed(8);
     turtle.set_pen_size(2.0);
     solve(&mut turtle, maze, cell_width, cell_height);
 }

--- a/examples/nestedcubes.rs
+++ b/examples/nestedcubes.rs
@@ -6,7 +6,7 @@ fn main() {
     let mut turtle = Turtle::new();
 
     turtle.drawing_mut().set_background_color("light grey");
-    turtle.set_speed(10);
+    turtle.set_speed(20);
     turtle.set_pen_size(2.0);
     for i in 0..290 {
         turtle.set_pen_color(Color {

--- a/examples/randomcolors.rs
+++ b/examples/randomcolors.rs
@@ -6,6 +6,7 @@ fn main() {
     let mut turtle = Turtle::new();
 
     turtle.set_speed(8);
+    turtle.set_speed(20);
     turtle.set_pen_size(2.0);
     for i in 0..300 {
         turtle.drawing_mut().set_background_color(random::<Color>().opaque());

--- a/examples/runtest.rs
+++ b/examples/runtest.rs
@@ -22,12 +22,12 @@ fn main() {
 /// These are cases that need to be checked in a real, running turtle instance and cannot be
 /// checked in the test environment
 fn run_tests(turtle: &mut Turtle) {
-    move_rotate_ignores_nan_inf_zero(turtle);
+    ignores_nan_inf_zero(turtle);
     ignores_nan_inf(turtle);
     ignores_zero(turtle);
 }
 
-fn move_rotate_ignores_nan_inf_zero(turtle: &mut Turtle) {
+fn ignores_nan_inf_zero(turtle: &mut Turtle) {
     turtle.forward(0.0);
     turtle.forward(::std::f64::NAN);
     turtle.forward(::std::f64::INFINITY);
@@ -52,11 +52,6 @@ fn move_rotate_ignores_nan_inf_zero(turtle: &mut Turtle) {
     turtle.wait(::std::f64::NAN);
     turtle.wait(::std::f64::INFINITY);
     turtle.wait(-::std::f64::INFINITY);
-
-    turtle.set_speed(0.0);
-    turtle.set_speed(::std::f64::NAN);
-    turtle.set_speed(::std::f64::INFINITY);
-    turtle.set_speed(-::std::f64::INFINITY);
 }
 
 fn ignores_nan_inf(turtle: &mut Turtle) {

--- a/examples/rust.rs
+++ b/examples/rust.rs
@@ -12,7 +12,6 @@ use turtle::Turtle;
 fn main() {
     let mut turtle = Turtle::new();
 
-    turtle.set_speed(5);
     turtle.set_fill_color("black");
 
     turtle.begin_fill();

--- a/examples/rust.rs
+++ b/examples/rust.rs
@@ -9,12 +9,10 @@ extern crate turtle;
 
 use turtle::Turtle;
 
-const SPEED: i32 = 7;
-
 fn main() {
     let mut turtle = Turtle::new();
 
-    turtle.set_speed(SPEED);
+    turtle.set_speed(5);
     turtle.set_fill_color("black");
 
     turtle.begin_fill();
@@ -145,7 +143,6 @@ fn letter(turtle: &mut Turtle) {
         turtle.right(1.5);
     }
 
-    turtle.set_speed(SPEED);
     turtle.forward(52.0);
     turtle.right(90.0);
     turtle.forward(50.0);

--- a/examples/rust.rs
+++ b/examples/rust.rs
@@ -136,15 +136,13 @@ fn letter(turtle: &mut Turtle) {
 
     turtle.set_pen_size(12.0);
     turtle.forward(110.0);
-    for _ in 0..600 {
+    for _ in 0..120 {
         // By going forward and then backward, we avoid any "gaps" between the very small movements
         // To see why this is needed, try replacing this with a single movement of the difference
-        // between the two.
-        turtle.forward(0.5);
-        turtle.set_speed("instant");
-        turtle.backward(0.4);
-        turtle.right(0.3);
-        turtle.set_speed(10);
+        // between the two movements.
+        turtle.forward(1.0);
+        turtle.backward(0.5);
+        turtle.right(1.5);
     }
 
     turtle.set_speed(SPEED);
@@ -162,19 +160,15 @@ fn letter(turtle: &mut Turtle) {
     turtle.pen_down();
 
     turtle.forward(40.0);
-    for _ in 0..400 {
-        turtle.forward(0.5);
-        turtle.set_speed("instant");
-        turtle.backward(0.4);
-        turtle.right(0.2);
-        turtle.set_speed(10);
+    for _ in 0..80 {
+        turtle.forward(1.0);
+        turtle.backward(0.5);
+        turtle.right(1.0);
     }
 
-    for _ in 0..200 {
-        turtle.forward(0.5);
-        turtle.set_speed("instant");
-        turtle.backward(0.4);
-        turtle.left(0.1);
-        turtle.set_speed(10);
+    for _ in 0..40 {
+        turtle.forward(1.0);
+        turtle.backward(0.5);
+        turtle.left(0.5);
     }
 }

--- a/examples/snowflake.rs
+++ b/examples/snowflake.rs
@@ -12,7 +12,7 @@ fn main() {
     turtle.set_pen_color("#B2EBF2");
 
     turtle.pen_up();
-    turtle.set_speed(11);
+    turtle.set_speed("instant");
     turtle.backward(200.0);
     turtle.right(30.0);
     turtle.pen_down();

--- a/examples/snowflake.rs
+++ b/examples/snowflake.rs
@@ -17,7 +17,7 @@ fn main() {
     turtle.right(30.0);
     turtle.pen_down();
 
-    turtle.set_speed(10);
+    turtle.set_speed("fast");
     fractal(&mut turtle, 350.0, 3);
     turtle.left(120.0);
     fractal(&mut turtle, 350.0, 3);

--- a/examples/snowman.rs
+++ b/examples/snowman.rs
@@ -8,22 +8,18 @@ fn main() {
     let mut turtle = Turtle::new();
 
     turtle.pen_up();
-    turtle.set_speed("instant");
     turtle.backward(250.0);
     turtle.left(90.0);
     turtle.pen_down();
-    turtle.set_speed(6);
 
     for &radius in [120.0, 80.0, 60.0].into_iter() {
         circle(&mut turtle, radius);
 
-        turtle.set_speed("instant");
         turtle.pen_up();
         turtle.right(90.0);
         turtle.forward(radius * 2.0);
         turtle.left(90.0);
         turtle.pen_down();
-        turtle.set_speed(6);
     }
 
     turtle.hide();

--- a/examples/speedtest.rs
+++ b/examples/speedtest.rs
@@ -10,13 +10,13 @@ fn main() {
     turtle.pen_up();
     turtle.set_speed("instant");
     turtle.left(90.0);
-    turtle.forward(300.0);
+    turtle.forward(350.0);
     turtle.right(90.0);
     turtle.pen_down();
 
     let length = 200.0;
 
-    for i in 1..12 {
+    for i in 1..25 {
         turtle.set_speed(i);
         turtle.forward(length);
 
@@ -24,7 +24,7 @@ fn main() {
         turtle.set_speed("instant");
         turtle.backward(length);
         turtle.right(90.0);
-        turtle.forward(60.0);
+        turtle.forward(30.0);
         turtle.left(90.0);
         turtle.pen_down();
     }

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -71,7 +71,6 @@ fn get_color(position: Point) -> Color {
 
 fn main() {
     let mut turtle = Turtle::new();
-    turtle.set_speed(10);
 
     // The side of the first large square
     let side = 100.0;

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -188,7 +188,7 @@
 //! [`random_range()`]: fn.random_range.html
 //! [`Distance`]: ../type.Distance.html
 //! [`Angle`]: ../type.Angle.html
-//! [`Speed`]: ../speed/enum.Speed.html
+//! [`Speed`]: ../speed/struct.Speed.html
 //! [`Color`]: ../color/struct.Color.html
 //! [`Point`]: ../struct.Point.html
 

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -43,7 +43,7 @@
 //!
 //! * [`Distance`] - `f64` values greater than or equal to `0.0` and less than `1.0`
 //! * [`Angle`] - `f64` values greater than or equal to `0.0` and less than `1.0`
-//! * [`Speed`] - any of the speed values including instant
+//! * [`Speed`] - any speed value in the valid range, not including instant
 //! * [`Color`] - colors with random red, green, blue and alpha values (use
 //!   [`opaque()`](../color/struct.Color.html#method.opaque) to get a solid random color)
 //! * [`Point`] - a random point with two `f64` values greater than or equal to `0.0` and less than `1.0`

--- a/src/speed.rs
+++ b/src/speed.rs
@@ -30,6 +30,17 @@ pub(crate) enum SpeedLevel {
 /// assert_eq!(speed, Speed::from(1));
 /// ```
 ///
+/// To check if a speed is instant, use the `is_instant()` method or compare the speed to
+/// [`Speed::instant()`](struct.Speed.html#method.instant).
+///
+/// ```rust
+/// # use turtle::Speed;
+/// let speed = Speed::instant();
+/// if speed.is_instant() {
+///     println!("Super fast!!");
+/// }
+/// ```
+///
 /// There is no need to call `.into()` when passing a speed into the
 /// [`Turtle::set_speed` method](struct.Turtle.html#method.set_speed).
 ///
@@ -49,10 +60,25 @@ impl Speed {
     ///
     /// ```rust
     /// use turtle::{Speed};
-    /// assert_eq!(Speed::instant(), 0);
+    /// let speed = Speed::instant();
+    /// assert!(speed.is_instant());
     /// ```
     pub fn instant() -> Self {
         Speed(SpeedLevel::Instant)
+    }
+
+    /// Returns true if this speed is the same as `Speed::instant()`
+    ///
+    /// ```rust
+    /// use turtle::{Speed};
+    /// let speed: Speed = "instant".into();
+    /// assert!(speed.is_instant());
+    /// ```
+    pub fn is_instant(self) -> bool {
+        match self {
+            Speed(SpeedLevel::Instant) => true,
+            _ => false,
+        }
     }
 
     /// Converts a speed to its value as a movement speed in pixels per second
@@ -77,10 +103,10 @@ impl Speed {
 impl fmt::Display for Speed {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::SpeedLevel::*;
-        write!(f, "{}", match self.0 {
-            Value(speed) => speed,
-            Instant => 0,
-        })
+        match self.0 {
+            Value(speed) => write!(f, "Speed::from({})", speed),
+            Instant => write!(f, "Speed::instant()"),
+        }
     }
 }
 
@@ -118,9 +144,9 @@ impl From<i32> for Speed {
         use self::SpeedLevel::*;
 
         Speed(match n {
-            0 => Instant,
+            0 => panic!("Invalid speed: 0. If you wanted to set the speed to instant, please use the string \"instant\" or Speed::instant()"),
             n if n <= MAX_SPEED => Value(n),
-            n => panic!("Invalid speed: {}. Must be a value between 0 and {}", n, MAX_SPEED),
+            n => panic!("Invalid speed: {}. Must be a value between 1 and {}", n, MAX_SPEED),
         })
     }
 }
@@ -141,9 +167,11 @@ mod tests {
 
     #[test]
     fn display() {
-        for value in 0..MAX_SPEED {
+        let speed: Speed = "instant".into();
+        assert_eq!(format!("{}", speed), "Speed::instant()");
+        for value in 1..MAX_SPEED {
             let speed: Speed = value.into();
-            assert_eq!(format!("{}", speed), value.to_string());
+            assert_eq!(format!("{}", speed), format!("Speed::from({})", value));
         }
     }
 
@@ -163,7 +191,7 @@ mod tests {
         turtle.set_speed("faster");
         assert_eq!(turtle.speed(), 15);
         turtle.set_speed("instant");
-        assert_eq!(turtle.speed(), 0);
+        assert_eq!(turtle.speed(), Speed::instant());
     }
 
     #[test]
@@ -176,32 +204,30 @@ mod tests {
     #[test]
     fn speed_values() {
         let mut turtle = Turtle::new();
-        for speed in 0..MAX_SPEED {
+        for speed in 1..MAX_SPEED {
             turtle.set_speed(speed);
             assert_eq!(turtle.speed(), speed);
         }
     }
 
     #[test]
-    #[should_panic(expected = "Invalid speed: 26. Must be a value between 0 and 25")]
+    #[should_panic(expected = "Invalid speed: 26. Must be a value between 1 and 25")]
     fn speed_value_out_of_range() {
         let mut turtle = Turtle::new();
         turtle.set_speed(26);
-        assert_eq!(turtle.speed(), 0);
     }
 
     #[test]
-    #[should_panic(expected = "Invalid speed: 20394. Must be a value between 0 and 25")]
+    #[should_panic(expected = "Invalid speed: 20394. Must be a value between 1 and 25")]
     fn speed_value_out_of_range2() {
         let mut turtle = Turtle::new();
         turtle.set_speed(20394);
-        assert_eq!(turtle.speed(), 0);
     }
 
     #[test]
     fn speed_values_f64() {
         let mut turtle = Turtle::new();
-        for speed in 0..MAX_SPEED {
+        for speed in 1..MAX_SPEED {
             turtle.set_speed(speed as f64 + 0.4);
             assert_eq!(turtle.speed(), speed);
         }

--- a/src/speed.rs
+++ b/src/speed.rs
@@ -30,8 +30,8 @@ pub(crate) enum SpeedLevel {
 /// assert_eq!(speed, Speed::from(1));
 /// ```
 ///
-/// To check if a speed is instant, use the `is_instant()` method or compare the speed to
-/// [`Speed::instant()`](struct.Speed.html#method.instant).
+/// To check if a speed is instant, use the [`is_instant()` method] or compare the speed to
+/// [`Speed::instant()`].
 ///
 /// ```rust
 /// # use turtle::Speed;
@@ -41,8 +41,7 @@ pub(crate) enum SpeedLevel {
 /// }
 /// ```
 ///
-/// There is no need to call `.into()` when passing a speed into the
-/// [`Turtle::set_speed` method](struct.Turtle.html#method.set_speed).
+/// There is no need to call `.into()` when passing a speed into the [`set_speed` method].
 ///
 /// ```rust
 /// # use turtle::{Turtle};
@@ -50,7 +49,11 @@ pub(crate) enum SpeedLevel {
 /// turtle.set_speed(22);
 /// ```
 ///
-/// See the [`Turtle::set_speed` method](struct.Turtle.html#method.set_speed) for more information.
+/// See the [`set_speed` method] for more information.
+///
+/// [`set_speed` method]: struct.Turtle.html#method.set_speed
+/// [`Speed::instant()`]: struct.Speed.html#method.instant
+/// [`is_instant()` method]: struct.Speed.html#method.is_instant
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Speed(SpeedLevel);
 

--- a/src/speed.rs
+++ b/src/speed.rs
@@ -211,7 +211,7 @@ impl Speed {
     pub(crate) fn to_movement(self) -> Distance {
         use self::SpeedLevel::*;
         match self.0 {
-            Value(speed) => speed as f64 * 500.0,
+            Value(speed) => speed as f64 * 50.0,
             Instant => f64::INFINITY,
         }
     }
@@ -220,7 +220,7 @@ impl Speed {
     pub(crate) fn to_rotation(self) -> Radians {
         use self::SpeedLevel::*;
         Radians::from_radians_value(match self.0 {
-            Value(speed) => speed as f64 * (2.0*PI),
+            Value(speed) => speed as f64 * (3.0*PI),
             Instant => f64::INFINITY,
         })
     }

--- a/src/speed.rs
+++ b/src/speed.rs
@@ -269,7 +269,7 @@ impl<'a> From<&'a str> for Speed {
             "fast" => Value(12),
             "faster" => Value(15),
             "instant" => Instant,
-            _ => panic!("Invalid speed specified, use one of the words: 'slowest', 'slower', 'slow', 'normal', 'fast', 'faster', 'instant'"),
+            _ => panic!("Invalid speed specified, use one of the words: \"slowest\", \"slower\", \"slow\", \"normal\", \"fast\", \"faster\", \"instant\""),
         })
     }
 }
@@ -282,7 +282,7 @@ impl From<i32> for Speed {
             // Special error message for 0 because this used to be a valid speed
             0 => panic!("Invalid speed: 0. If you wanted to set the speed to instant, please use the string \"instant\" or Speed::instant()"),
             n if n >= MIN_SPEED && n <= MAX_SPEED => Value(n),
-            n => panic!("Invalid speed: {}. Must be a value between 1 and {}", n, MAX_SPEED),
+            n => panic!("Invalid speed: {}. Must be a value between {} and {}", n, MIN_SPEED, MAX_SPEED),
         })
     }
 }
@@ -331,7 +331,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Invalid speed specified, use one of the words: 'slowest', 'slower', 'slow', 'normal', 'fast', 'faster', 'instant'")]
+    #[should_panic(expected = "Invalid speed specified, use one of the words: \"slowest\", \"slower\", \"slow\", \"normal\", \"fast\", \"faster\", \"instant\"")]
     fn invalid_speed() {
         let mut turtle = Turtle::new();
         turtle.set_speed("wrong");
@@ -340,7 +340,7 @@ mod tests {
     #[test]
     fn speed_values() {
         let mut turtle = Turtle::new();
-        for speed in 1..MAX_SPEED {
+        for speed in 1..(MAX_SPEED + 1) {
             turtle.set_speed(speed);
             assert_eq!(turtle.speed(), speed);
         }

--- a/src/speed.rs
+++ b/src/speed.rs
@@ -72,13 +72,13 @@ impl PartialOrd for SpeedLevel {
 ///
 /// | String      | Value |
 /// | ----------- | ----- |
-/// | `"slowest"`   | `1`   |
-/// | `"slower"`    | `5`   |
-/// | `"slow"`      | `8`   |
-/// | `"normal"`    | `10`  |
-/// | `"fast"`      | `12`  |
-/// | `"faster"`    | `15`  |
-/// | `"instant"`   | [see below](#instant) |
+/// | `"slowest"` | `1`   |
+/// | `"slower"`  | `5`   |
+/// | `"slow"`    | `8`   |
+/// | `"normal"`  | `10`  |
+/// | `"fast"`    | `12`  |
+/// | `"faster"`  | `15`  |
+/// | `"instant"` | [see below](#instant) |
 ///
 /// You can use strings to create `Speed` values in the same way numbers were used above. All
 /// three of the following are equivalent:
@@ -125,20 +125,23 @@ impl PartialOrd for SpeedLevel {
 /// assert_eq!(speed, Speed::from("slowest"));
 /// ```
 ///
-/// ```rust
-/// # use turtle::Speed;
-/// let speed: Speed = 12.into();
+/// You can use the `<`, `<=`, `==`, `>=`, `>` with `Speed` values and `i32` values or other
+/// `Speed` values.
+///
+/// ```rust,no_run
+/// # use turtle::{Turtle, Speed};
+/// let turtle = Turtle::new();
+/// let speed = turtle.speed();
 /// if speed == 12 && speed >= 5 && speed < Speed::instant() {
 ///     println!("Super fast!!");
 /// }
-/// # else { panic!("Unable to compare a speed value!"); }
 /// // This is equivalent, but requires more typing
 /// if speed == Speed::from(12) && speed >= Speed::from(5) && speed < Speed::from("instant") {
 ///     println!("Super fast!!");
 /// }
 /// ```
 ///
-/// Notice that you can compare `Speed` values to numeric values, not the other way around.
+/// Notice that you can compare `Speed` values to numeric values, but not the other way around.
 ///
 /// ```rust,compile_fail
 /// # use turtle::Speed;

--- a/src/speed.rs
+++ b/src/speed.rs
@@ -1,33 +1,151 @@
 use std::fmt;
 use std::f64;
 use std::f64::consts::PI;
+use std::cmp::Ordering;
 
 use radians::Radians;
 use rand::{Rand, Rng};
 use {Distance};
 
+const MIN_SPEED: i32 = 1;
 const MAX_SPEED: i32 = 25;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, Hash, Serialize, Deserialize)]
 pub(crate) enum SpeedLevel {
     Value(i32),
     Instant,
 }
 
+impl PartialOrd for SpeedLevel {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        use self::SpeedLevel::*;
+        match (*self, *other) {
+            (Value(value), Value(ref other_value)) => value.partial_cmp(other_value),
+            (Instant, Instant) => Some(Ordering::Equal),
+            (Value(_), Instant) => Some(Ordering::Less),
+            (Instant, Value(_)) => Some(Ordering::Greater),
+        }
+    }
+}
+
 /// Represents both the movement and rotation speed of the turtle.
 ///
-/// You can create a `Speed` value by converting it from a number of different types. `Speed`
-/// values can be compared for equality with `i32` values. This is a little more convenient than
-/// converting the `i32` to `Speed` every time you want to make a comparison.
+/// # Creating Speeds
+///
+/// You can create a `Speed` value by converting either strings or numbers.
 ///
 /// ```rust
 /// # use turtle::Speed;
 /// // This value is of type `Speed` and it is converted from an `i32`
 /// let speed: Speed = 1.into();
+///
+/// // This value is of type `Speed` and it is converted from a `&str`
+/// let slowest_speed: Speed = "slowest".into();
+/// assert_eq!(speed, slowest_speed);
+/// ```
+///
+/// There is no need to call `.into()` when passing a speed into the [`set_speed` method].
+/// See the [`set_speed` method] for more information about how that works.
+///
+/// ```rust
+/// # use turtle::{Turtle};
+/// let mut turtle = Turtle::new();
+/// turtle.set_speed(22); // Same as `turtle.set_speed(22.into())`
+/// ```
+///
+/// **The minimum speed value is 1 and the maximum speed value (currently) is 25.**
+///
+/// Trying to set the speed to a value out of that range will cause a panic.
+///
+/// ```rust,should_panic
+/// # use turtle::{Turtle};
+/// let mut turtle = Turtle::new();
+/// turtle.set_speed(26); // panic!
+/// ```
+///
+/// While the minimum speed will not change, the maximum speed may grow larger if the need arises.
+/// That is why we chose to panic for invalid speeds instead of defaulting to another value.
+///
+/// ### String Conversion
+///
+/// Strings are converted as follows:
+///
+/// | String      | Value |
+/// | ----------- | ----- |
+/// | `"slowest"`   | `1`   |
+/// | `"slower"`    | `5`   |
+/// | `"slow"`      | `8`   |
+/// | `"normal"`    | `10`  |
+/// | `"fast"`      | `12`  |
+/// | `"faster"`    | `15`  |
+/// | `"instant"`   | [see below](#instant) |
+///
+/// You can use strings to create `Speed` values in the same way numbers were used above. All
+/// three of the following are equivalent:
+///
+/// ```rust
+/// # use turtle::{Turtle, Speed};
+/// # let mut turtle = Turtle::new();
+/// turtle.set_speed(5);
+/// turtle.set_speed("slower");
+/// turtle.set_speed(Speed::from("slower")); // Not recommended!
+/// ```
+///
+/// # Instant
+///
+/// There is one special speed value `"instant"` which makes it so that movement and rotation
+/// are not animated at all. Instead, the turtle immediately moves and rotates to the position that
+/// you directed it to. It will still draw along the way if its pen is down.
+///
+/// ```rust
+/// # use turtle::{Turtle};
+/// let mut turtle = Turtle::new();
+/// turtle.set_speed("instant");
+/// turtle.forward(100.0); // A line will be drawn instantly!
+/// ```
+///
+/// # Comparing Speed Values
+///
+/// `Speed` values can be compared for equality with `i32` values. This is a little more convenient
+/// than converting the `i32` to `Speed` every time you want to make a comparison.
+///
+/// ```rust
+/// # use turtle::Speed;
+/// let speed: Speed = 1.into();
 /// // Speed values can be compared to integers
 /// assert_eq!(speed, 1);
 /// // This is equivalent to the following
 /// assert_eq!(speed, Speed::from(1));
+///
+/// // This value is of type `Speed` and it is converted from a `&str`
+/// let speed: Speed = "slowest".into();
+/// // Speed values can be compared to integers
+/// assert_eq!(speed, 1);
+/// // This is equivalent to the following
+/// assert_eq!(speed, Speed::from("slowest"));
+/// ```
+///
+/// ```rust
+/// # use turtle::Speed;
+/// let speed: Speed = 12.into();
+/// if speed == 12 && speed >= 5 && speed < Speed::instant() {
+///     println!("Super fast!!");
+/// }
+/// # else { panic!("Unable to compare a speed value!"); }
+/// // This is equivalent, but requires more typing
+/// if speed == Speed::from(12) && speed >= Speed::from(5) && speed < Speed::from("instant") {
+///     println!("Super fast!!");
+/// }
+/// ```
+///
+/// Notice that you can compare `Speed` values to numeric values, not the other way around.
+///
+/// ```rust,compile_fail
+/// # use turtle::Speed;
+/// let speed: Speed = 7.into();
+/// if 8 > speed { // This doesn't make sense and won't compile!
+///     // ...
+/// }
 /// ```
 ///
 /// To check if a speed is instant, use the [`is_instant()` method] or compare the speed to
@@ -37,34 +155,36 @@ pub(crate) enum SpeedLevel {
 /// # use turtle::Speed;
 /// let speed = Speed::instant();
 /// if speed.is_instant() {
-///     println!("Super fast!!");
+///     println!("Instant!!");
 /// }
+/// # else { panic!("Speed::instant() was not instant!"); }
 /// ```
-///
-/// There is no need to call `.into()` when passing a speed into the [`set_speed` method].
-///
-/// ```rust
-/// # use turtle::{Turtle};
-/// let mut turtle = Turtle::new();
-/// turtle.set_speed(22);
-/// ```
-///
-/// See the [`set_speed` method] for more information.
 ///
 /// [`set_speed` method]: struct.Turtle.html#method.set_speed
 /// [`Speed::instant()`]: struct.Speed.html#method.instant
 /// [`is_instant()` method]: struct.Speed.html#method.is_instant
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Speed(SpeedLevel);
 
 impl Speed {
-    /// Returns the speed value that represents instantly moving and rotating with no further
-    /// animation
+    /// Returns the speed value that will make the turtle move and rotate instantly. This means
+    /// that instead of the turtle's movements being animated, it will directly move to wherever
+    /// you direct it to go.
     ///
     /// ```rust
-    /// use turtle::{Speed};
-    /// let speed = Speed::instant();
-    /// assert!(speed.is_instant());
+    /// # use turtle::{Turtle};
+    /// let mut turtle = Turtle::new();
+    /// turtle.set_speed(Speed::instant());
+    /// turtle.forward(100.0); // A line will be drawn instantly!
+    /// ```
+    ///
+    /// Whenever possible, you should prefer to use the string `"instant"` instead of calling this
+    /// method.
+    ///
+    /// ```rust
+    /// # use turtle::{Turtle};
+    /// # let mut turtle = Turtle::new();
+    /// turtle.set_speed("instant"); // equivalent to typing `Speed::instant()`
     /// ```
     pub fn instant() -> Self {
         Speed(SpeedLevel::Instant)
@@ -75,6 +195,9 @@ impl Speed {
     /// ```rust
     /// use turtle::{Speed};
     /// let speed: Speed = "instant".into();
+    /// assert!(speed.is_instant());
+    ///
+    /// let speed = Speed::instant();
     /// assert!(speed.is_instant());
     /// ```
     pub fn is_instant(self) -> bool {
@@ -113,6 +236,18 @@ impl fmt::Display for Speed {
     }
 }
 
+impl PartialEq<i32> for Speed {
+    fn eq(&self, other: &i32) -> bool {
+        self.eq(&Speed::from(*other))
+    }
+}
+
+impl PartialOrd<i32> for Speed {
+    fn partial_cmp(&self, other: &i32) -> Option<Ordering> {
+        return self.partial_cmp(&Speed::from(*other));
+    }
+}
+
 impl Rand for Speed {
     fn rand<R: Rng>(rng: &mut R) -> Self {
         (rng.gen::<i32>() % MAX_SPEED).into()
@@ -136,19 +271,14 @@ impl<'a> From<&'a str> for Speed {
     }
 }
 
-impl PartialEq<i32> for Speed {
-    fn eq(&self, other: &i32) -> bool {
-        self.eq(&Speed::from(*other))
-    }
-}
-
 impl From<i32> for Speed {
     fn from(n: i32) -> Self {
         use self::SpeedLevel::*;
 
         Speed(match n {
+            // Special error message for 0 because this used to be a valid speed
             0 => panic!("Invalid speed: 0. If you wanted to set the speed to instant, please use the string \"instant\" or Speed::instant()"),
-            n if n <= MAX_SPEED => Value(n),
+            n if n >= MIN_SPEED && n <= MAX_SPEED => Value(n),
             n => panic!("Invalid speed: {}. Must be a value between 1 and {}", n, MAX_SPEED),
         })
     }
@@ -225,6 +355,20 @@ mod tests {
     fn speed_value_out_of_range2() {
         let mut turtle = Turtle::new();
         turtle.set_speed(20394);
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid speed: -1. Must be a value between 1 and 25")]
+    fn speed_value_out_of_range_negative() {
+        let mut turtle = Turtle::new();
+        turtle.set_speed(-1);
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid speed: 0. If you wanted to set the speed to instant, please use the string \"instant\" or Speed::instant()")]
+    fn disallow_zero() {
+        let mut turtle = Turtle::new();
+        turtle.set_speed(0);
     }
 
     #[test]

--- a/src/speed.rs
+++ b/src/speed.rs
@@ -41,7 +41,7 @@ impl PartialOrd for SpeedLevel {
 ///
 /// // This value is of type `Speed` and it is converted from a `&str`
 /// let slowest_speed: Speed = "slowest".into();
-/// assert_eq!(speed, slowest_speed);
+/// # assert_eq!(speed, slowest_speed);
 /// ```
 ///
 /// There is no need to call `.into()` when passing a speed into the [`set_speed` method].
@@ -80,14 +80,15 @@ impl PartialOrd for SpeedLevel {
 /// | `"faster"`  | `15`  |
 /// | `"instant"` | [see below](#instant) |
 ///
-/// You can use strings to create `Speed` values in the same way numbers were used above. All
-/// three of the following are equivalent:
+/// You can use strings to create `Speed` values in the same way numbers were used above. Each of
+/// the following is an equivalent way to set the speed to `5`:
 ///
 /// ```rust
 /// # use turtle::{Turtle, Speed};
 /// # let mut turtle = Turtle::new();
 /// turtle.set_speed(5);
 /// turtle.set_speed("slower");
+/// turtle.set_speed(Speed::from(5)); // Not recommended!
 /// turtle.set_speed(Speed::from("slower")); // Not recommended!
 /// ```
 ///
@@ -119,14 +120,14 @@ impl PartialOrd for SpeedLevel {
 ///
 /// // This value is of type `Speed` and it is converted from a `&str`
 /// let speed: Speed = "slowest".into();
-/// // Speed values can be compared to integers
-/// assert_eq!(speed, 1);
-/// // This is equivalent to the following
+/// // Speed values can be compared to other speed values
 /// assert_eq!(speed, Speed::from("slowest"));
+/// // This is equivalent to the following since the slowest speed is 1
+/// assert_eq!(speed, 1);
 /// ```
 ///
-/// You can use the `<`, `<=`, `==`, `>=`, `>` with `Speed` values and `i32` values or other
-/// `Speed` values.
+/// You can use the `<`, `<=`, `==`, `>=`, `>` with `Speed` values and `i32` values (or other
+/// `Speed` values).
 ///
 /// ```rust,no_run
 /// # use turtle::{Turtle, Speed};

--- a/src/speed.rs
+++ b/src/speed.rs
@@ -172,7 +172,7 @@ impl Speed {
     /// you direct it to go.
     ///
     /// ```rust
-    /// # use turtle::{Turtle};
+    /// # use turtle::{Turtle, Speed};
     /// let mut turtle = Turtle::new();
     /// turtle.set_speed(Speed::instant());
     /// turtle.forward(100.0); // A line will be drawn instantly!
@@ -250,7 +250,7 @@ impl PartialOrd<i32> for Speed {
 
 impl Rand for Speed {
     fn rand<R: Rng>(rng: &mut R) -> Self {
-        (rng.gen::<i32>() % MAX_SPEED).into()
+        rng.gen_range(MIN_SPEED, MAX_SPEED + 1).into()
     }
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -48,7 +48,7 @@ impl Default for TurtleState {
             fill_color: color::BLACK,
             position: Point::origin(),
             heading: Radians::from_degrees_value(90.0),
-            speed: Speed::Five,
+            speed: "normal".into(),
             visible: true,
         }
     }

--- a/src/turtle_window.rs
+++ b/src/turtle_window.rs
@@ -98,7 +98,7 @@ impl TurtleWindow {
         if !distance.is_normal() {
             return;
         }
-        let speed = speed.to_absolute(); // px per second
+        let speed = speed.to_movement(); // px per second
         // We take the absolute value because the time is always positive, even if distance is negative
         let total_millis = (distance / speed * 1000.).abs();
 
@@ -126,7 +126,7 @@ impl TurtleWindow {
         };
         let end = start + movement;
 
-        let speed = speed.to_absolute(); // px per second
+        let speed = speed.to_movement(); // px per second
         // We take the absolute value because the time is always positive, even if distance is negative
         let total_millis = (distance / speed * 1000.).abs();
 


### PR DESCRIPTION
Fixes #14 

> This is a breaking change. After this is merged, we will likely publish the first release candidate version of turtle. Unlike alpha versions, release candidates make strong guarantees about breaking changes. Once RC 1 is published, we won't make anymore breaking changes unless something really drastic comes up.

Speed is an odd type because despite its meaning in English, in turtle, it represents two different quantities: movement speed **and** rotation speed. Because of that, it is hard to represent Speed as a single absolute value like "100 px per second". While the speed of `1` might mean "50 px per second" for movement instructions like `forward()` and `backward()`, it also means "9.425 radians per second" for rotation instructions like `right()` and `left()`.

This new implementation hides all of those details and makes it possible to expand the available speeds in the future without breaking a whole bunch of code. The previous enum could be matched against and used directly. By hiding the internal representation in the new type, such dependencies are not possible.