### PR TITLE
Using a value between 0.0 and 1.0 for all percentages

### DIFF
--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -17,7 +17,7 @@ fn main() {
     let white: Color = "white".into();
 
     for i in 0..100+1 {
-        turtle.set_pen_color(red.mix(white, i));
+        turtle.set_pen_color(red.mix(white, i as f64 / 100.0));
         turtle.forward(5.0);
     }
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -1324,11 +1324,19 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected="1.01 is not a valid value for weight, values must be between 0.0 and 1.0.")]
+    #[should_panic(expected="1.0000001 is not a valid value for weight, values must be between 0.0 and 1.0.")]
     fn ensure_mix_invalid_weight_panic() {
         let o: Color = "orange".into();
         let r: Color = "red".into();
-        let _ = o.mix(r, 1.01);
+        let _ = o.mix(r, 1.0000001);
+    }
+
+    #[test]
+    #[should_panic(expected="-0.0000001 is not a valid value for weight, values must be between 0.0 and 1.0.")]
+    fn ensure_mix_negative_weight_panic() {
+        let o: Color = "orange".into();
+        let r: Color = "red".into();
+        let _ = o.mix(r, -0.0000001);
     }
 
     #[test]
@@ -1423,13 +1431,6 @@ mod tests {
         let expected = Color::rgba(72., 44., 163., 0.88);
         let mix_res = mix_1.mix(mix_2, 0.40);
         assert_eq!(expected, mix_res);
-    }
-
-    #[test]
-    #[should_panic(expected = "1.01 is not a valid value for weight, values must be between 0.0 and 1.0.")]
-    fn invalid_mix_weight() {
-        let c1 = Color::rgb(1., 1., 1.);
-        let _ = c1.mix([2., 2., 2.], 1.01);
     }
 
     #[test]


### PR DESCRIPTION
Hi @stevepentland! I noticed while reviewing #72 that we use a value between 0.0 and 1.0 to represent a percentage everywhere except for in `mix`. I think this discrepency could cause unwanted confusion, so I went ahead and updated `mix` to use the same convention as everything else.

If you have a few minutes, could you please give this a review so we can be sure I've done this correctly? :smile: 

Here's a screenshot of the docs in case that is helpful in reviewing:
![screenshot from 2018-04-17 21-55-38](https://user-images.githubusercontent.com/530939/38907539-2b17ce4c-428a-11e8-8028-db49736cd51d.png)
