### PR TITLE
Fixes #67 - Crash on macOS. piston_window version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde = "^1.0.23"
 serde_derive = "^1.0.23"
 serde_json = "^1.0.6"
 
-piston_window = "^0.73.0"
+piston_window = "^0.79.0"
 interpolation = "^0.1.0"
 rand = "^0.4.2"
 


### PR DESCRIPTION
This brings in the bug fix from [piston_window #227](https://github.com/PistonDevelopers/piston_window/issues/227).