### PR TITLE
Sleep the thread during wait_for_click to avoid pegging the CPU.

### DIFF
--- a/src/turtle.rs
+++ b/src/turtle.rs
@@ -1033,6 +1033,9 @@ impl Turtle {
             if let Some(Event::MouseButtonReleased(MouseButton::Left)) = self.drawing_mut().poll_event() {
                 break;
             }
+
+            // Sleep for ~1 frame (at 120fps) to avoid pegging the CPU.
+            thread::sleep(Duration::from_millis(1000 / 120));
         }
     }
 }


### PR DESCRIPTION
Fixes Issue #92 by adding a sleep as suggested.