### PR TITLE
Hide unstable drawing features behind unstable cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ include = ["/README.md", "LICENSE", "CODE_OF_CONDUCT.md", "CONTRIBUTING.md",
   "CHANGELOG.md", "src/**/*.rs", "examples/**/*.rs", "examples/**/*.txt",
   "tests/**/*.rs", "Cargo.toml", ".rustfmt.toml", "rust-toolchain"]
 
+# Make sure docs are always generated with the "unstable" feature activated
+[package.metadata.docs.rs]
+features = [ "unstable" ]
+
 [badges]
 # Appveyor: `repository` is required. `branch` is optional; default is `master`
 appveyor = { repository = "sunjay/turtle" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,6 @@ piston_window = "0.89"
 # NOTE: This means that tests MUST be run with:
 #   cargo test --features "test"
 test = []
+
+# Feature flag to disable unstable features by default and make consumers explicitly activate them.
+unstable = []

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -343,6 +343,7 @@ impl Drawing {
     /// button on the window. This method is reliable until that button is pressed. Since there is
     /// no way to tell when that is, treat the value returned from this method as unreliable and
     /// potentially inaccurate.
+    #[cfg(feature = "unstable")]
     pub fn is_maximized(&self) -> bool {
         self.window.borrow().fetch_drawing().maximized
     }
@@ -373,6 +374,7 @@ impl Drawing {
     ///
     /// It is usually okay to use this method right when the turtle is created, but don't rely on
     /// it after that because by then the user may have pressed the maximize button on the window.
+    #[cfg(feature = "unstable")]
     pub fn maximize(&mut self) {
         self.window.borrow_mut().with_drawing_mut(|drawing| drawing.maximized = true);
     }
@@ -403,6 +405,7 @@ impl Drawing {
     /// button on the window. This method is reliable until that button is pressed. Since there is
     /// no way to tell when that is, treat the value returned from this method as unreliable and
     /// potentially inaccurate.
+    #[cfg(feature = "unstable")]
     pub fn unmaximize(&mut self) {
         self.window.borrow_mut().with_drawing_mut(|drawing| drawing.maximized = false);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,19 @@
 //! things without creating the entire event loop. For example, use
 //! [`wait_for_click()`](struct.Turtle.html#method.wait_for_click) to wait for the user to click
 //! anywhere on the screen before proceeding.
+//! # Unstable features
+//! Some parts of this library are unstable, such as maximizing and unmaximizing the window.
+//! You can explicitly opt-in to using those features with the `unstable` feature like so:
+//! 
+//! ```bash
+//! $ cargo build --features "unstable"
+//! ```
+//! 
+//! If you want to use this from inside your own crate, you will need to add this to your Cargo.toml
+//! ```toml
+//! [dependencies]
+//! turtle = { version = "...", features = ["unstable"] }
+//! ```
 
 #![cfg_attr(target_arch = "wasm32", crate_type = "cdylib")]
 


### PR DESCRIPTION
This adds an `unstable` cargo feature to disable the unstable `drawing` features by default and make consumers explicitly activate them.

This addresses https://github.com/sunjay/turtle/issues/125