### PR TITLE
Add Turtle Logo to Docs Pages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@
 //! turtle = { version = "...", features = ["unstable"] }
 //! ```
 
+#![doc(html_logo_url = "https://raw.githubusercontent.com/sunjay/turtle/master/docs/assets/images/turtle-logo-512.png")]
 #![cfg_attr(target_arch = "wasm32", crate_type = "cdylib")]
 
 #[cfg(all(test, not(feature = "test")))]


### PR DESCRIPTION
This commit adds the project logo to the docs pages.
Full syntax of the #[doc] attribute is avaulable here: https://doc.rust-lang.org/rustdoc/the-doc-attribute.html

Fixes: #138