### PR TITLE
Re-enable smoke test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ pool:
 
 steps:
 - script: |
-    apt-get install mesa-utils
+    sudo apt-get install mesa-utils
     glxinfo
   displayName: dependencies (Linux)
   condition: in(variables['agent.os'], 'Linux')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,7 +72,6 @@ steps:
 - script: |
     cargo run --verbose --example runtest
   displayName: "smoke test"
-  enabled: false
 
 - script: |
     cargo test --verbose --features "test" --all

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,6 +48,7 @@ steps:
     echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
     source $HOME/.cargo/env
     rustc --version --verbose
+    glxinfo
   displayName: install
   condition: ne( variables['Agent.OS'], 'Windows_NT' )
 - script: |
@@ -56,6 +57,7 @@ steps:
     rustup-init.exe -y --default-toolchain %RUSTUP_TOOLCHAIN%
     echo "##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\.cargo\bin"
     rustc --version --verbose
+    glxinfo
   displayName: install (windows)
   condition: eq( variables['Agent.OS'], 'Windows_NT' )
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,11 @@ pool:
   vmImage: $(imageName)
 
 steps:
+- script: |
+    apt-get install mesa-utils
+    glxinfo
+  displayName: dependencies (Linux)
+  condition: in(variables['agent.os'], 'Linux')
 # Need to remove rust-toolchain or we will always use the version specified
 # there regardless of what version is installed
 # Also need to set the PATH environment variable
@@ -48,7 +53,6 @@ steps:
     echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
     source $HOME/.cargo/env
     rustc --version --verbose
-    glxinfo
   displayName: install
   condition: ne( variables['Agent.OS'], 'Windows_NT' )
 - script: |
@@ -57,7 +61,6 @@ steps:
     rustup-init.exe -y --default-toolchain %RUSTUP_TOOLCHAIN%
     echo "##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\.cargo\bin"
     rustc --version --verbose
-    glxinfo
   displayName: install (windows)
   condition: eq( variables['Agent.OS'], 'Windows_NT' )
 


### PR DESCRIPTION
In order to avoid issues like #27, #63, #67, and #94, it's important that we figure out a way to actually run a turtle program as part of our CI. We have a ["runtest" example](https://github.com/sunjay/turtle/blob/fb7733f8d1f43ddecd12f6db2039d1a174c03be5/examples/runtest.rs) that's specifically meant for this. It opens a window, performs some simple commands, and exits.

This PR re-enables the runtest to see if we can figure out how to get it work on all three platforms: Windows, Mac, Linux (Ubuntu).

I believe we'll need to do something to make sure that OpenGL and the right graphics drivers are installed and available for use. Not quite sure just yet, so any help is appreciated!

cc #106. Follow-up PR from #154.