### PR TITLE
Example/bits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,11 @@ rand = "0.6"
 
 svg = "0.6.0"
 
+# Dependencies used when developing `turtle` directly, but not when using it as
+# a library.
+[dev-dependencies]
+bitvec = "0.16"
+
 # Dependencies that don't support / shouldn't be used with WASM
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 piston_window = "0.105"

--- a/examples/bits.rs
+++ b/examples/bits.rs
@@ -3,15 +3,23 @@
 //! This example uses [@myrrlyn]’s [`bitvec`] crate to turn data into strings of
 //! bits, and then draws them on the screen.
 //!
+//! You are encouraged to change both the data used to seed the turtle, and the
+//! `bitvec` calls that control how the turtle acts, to see what changes.
+//!
 //! [@myrrlyn]: //github.com/myrrlyn
 //! [`bitvec`]: //crates.io/crates/bitvec
 
+// The `bitvec` crate provides a bunch of types for us to use with one import
 use bitvec::prelude::*;
 use turtle::Turtle;
 
+/// Set the line length for each displayed bit
 const BIT_WIDTH: f64 = 20.0;
+/// Set the vertical spacing between successive rows of bits
 const BIT_HEIGHT: f64 = 10.0;
+/// Set the horizontal spacing between successive bits in a row
 const BIT_MARGIN: f64 = BIT_WIDTH / 2.0;
+/// Compute the total width of a bit plus its spacing
 const BIT_BOX: f64 = BIT_WIDTH + BIT_MARGIN;
 
 fn main() {
@@ -24,10 +32,13 @@ fn main() {
     // then backtracking and walking vertically to the next byte.
     let mut turtle = Turtle::new();
     turtle.pen_up();
+    // Compute the boundaries of the part of the screen where the turtle will
+    // draw
     let right_edge = BIT_BOX * 4.0;
     let top_edge = BIT_HEIGHT * (text.len() as f64 / 2.0);
-    // The turtle starts from the top right of the region, and moves left
+    // The turtle starts from the top right of the region,
     turtle.go_to((right_edge, top_edge));
+    // and walks left
     turtle.set_heading(180.0);
 
     // Now let’s draw some data on the screen, as individual bits
@@ -60,21 +71,23 @@ fn main() {
     let bits = raw_number.bits::<BigEndian>();
 
     // Since we are reading bits from left to right, the turtle should move from
-    // left to right also.
-    let left_edge = -right_edge;
-    turtle.set_x(left_edge * 2.0);
+    // left to right also. Change the `* 2.0` to move the section horizontally.
+    let left_edge = -right_edge * 2.0;
+    turtle.set_x(left_edge);
+    // Walk from left to right
     turtle.set_heading(0.0);
 
     // The `&BitSlice` type acts just like `&[bool]`, so it comes with a
     // `.chunks` method which divides it into smaller pieces. `bitvec` can take
     // any number, not just multiples of 8, but 16 is a convenient number to
-    // look at.
+    // look at. Try changing it to a different number, like 10, to see what
+    // happens!
     for row in bits.chunks(16) {
         // Each chunk produced is a smaller `&BitSlice`, just like
         // `&[bool].chunks` produces smaller `&[bool]`s, so we can draw it.
         draw_row(&mut turtle, row);
         // After each row, the turtle has to go back to the left edge.
-        turtle.set_x(left_edge * 2.0);
+        turtle.set_x(left_edge);
     }
 }
 
@@ -96,8 +109,9 @@ where C: Cursor, T: BitStore {
             t.set_pen_color("light grey");
         }
 
-        // For each bit, the loop puts down the pen to draw a line of the bit
-        // color, then picks up the pen to add some spacing between them
+        // For each bit, the loop puts down the pen to draw a line of the bit’s
+        // color, then picks up the pen to add some horizontal spacing between
+        // them.
         t.pen_down();
         t.forward(BIT_WIDTH);
         t.pen_up();
@@ -114,5 +128,5 @@ where C: Cursor, T: BitStore {
     t.forward(BIT_HEIGHT);
     // then goes back to its old direction.
     t.set_heading(old_heading);
-    // This way each row gets spacing between them.
+    // This way each row gets vertical spacing between them.
 }

--- a/examples/bits.rs
+++ b/examples/bits.rs
@@ -82,30 +82,6 @@ fn main() {
     turtle.right(180.0);
 
     draw_number(&mut turtle, NUMBER);
-
-    // Reader exercise:
-    //
-    // The IEEE-754 format for `f64` numbers separates them into three parts:
-    //
-    // 1. The sign marks whether the number is positive or negative: 1 bit
-    // 2. The exponent marks how far from zero the number is: 11 bits
-    // 3. The fraction describes the number: 52 bits.
-    //
-    // Using these widths (1 bit, 11 bits, 52 bits), the knowledge that
-    // `&BitSlice` is a normal Rust slice, and the API documentation for
-    // `std::iter::Iterator`, see if you can display each portion of an `f64`
-    // as its own row.
-    //
-    // Hints:
-    //
-    // - The variable `bits` is set up to view the entire number, from most
-    // significant bit to least.
-    // - You can get access to a structure that performs iteration by calling
-    //   `bits.iter()`.
-    // - You can use the `Iterator::by_ref` method to prevent `Iterator` adapter
-    //   functions from destroying the source iterator.
-    // - `&BitSlice` is an ordinary Rust slice, so you can use `[start .. end]`
-    //   range indexing to get smaller pieces of it.
 }
 
 /// Draws the bits of a text span on the screen.
@@ -191,6 +167,30 @@ fn draw_number(turtle: &mut Turtle, number: f64) {
 
         next_row(turtle, -90.0);
     }
+
+    // Reader exercise:
+    //
+    // The IEEE-754 format for `f64` numbers separates them into three parts:
+    //
+    // 1. The sign marks whether the number is positive or negative: 1 bit
+    // 2. The exponent marks how far from zero the number is: 11 bits
+    // 3. The fraction describes the number: 52 bits.
+    //
+    // Using these widths (1 bit, 11 bits, 52 bits), the knowledge that
+    // `&BitSlice` is a normal Rust slice, and the API documentation for
+    // `std::iter::Iterator`, see if you can display each portion of an `f64`
+    // as its own row.
+    //
+    // Hints:
+    //
+    // - The variable `bits` is set up to view the entire number, from most
+    // significant bit to least.
+    // - You can get access to a structure that performs iteration by calling
+    //   `bits.iter()`.
+    // - You can use the `Iterator::by_ref` method to prevent `Iterator` adapter
+    //   functions from destroying the source iterator.
+    // - `&BitSlice` is an ordinary Rust slice, so you can use `[start .. end]`
+    //   range indexing to get smaller pieces of it.
 }
 
 /// Draw a row of bits on the screen.

--- a/examples/bits.rs
+++ b/examples/bits.rs
@@ -42,6 +42,72 @@ const BIT_MARGIN: f64 = BIT_WIDTH / 2.0;
 /// Compute the total width of a bit plus its spacing
 const BIT_BOX: f64 = BIT_WIDTH + BIT_MARGIN;
 
+fn main() {
+    // This block sets up the turtle to draw bits more or less centered in the
+    // screen. The turtle works by walking horizontally for each bit in a byte,
+    // then backtracking and walking vertically to the next byte.
+    let mut turtle = Turtle::new();
+    // The turtle starts in the center of the screen, but we want to move it
+    // around before drawing.
+    turtle.pen_up();
+
+    // Compute the boundaries of the part of the screen where the turtle will
+    // draw. We expect to be drawing eight bits, with half to the right of
+    // center and half to the left.
+    let right_edge = BIT_BOX * 8.0 / 2.0;
+    // We also expect to be drawing a row for each byte in the text, with an
+    // additional separator row for each *character*, half above and half below
+    // the center of the screen. This computes how many rows of text we will
+    // draw, then moves the turtle appropriately.
+    let byte_rows = TEXT.len();
+    let char_gaps = TEXT.chars().count();
+    let top_edge = BIT_HEIGHT * ((byte_rows + char_gaps) as f64 / 2.0);
+    // The turtle starts from the top right of the region,
+    turtle.forward(top_edge);
+    turtle.right(90.0);
+    turtle.forward(right_edge);
+    // and walks left
+    turtle.left(180.0);
+
+    draw_text(&mut turtle, TEXT);
+
+    // The `draw_number` function reads bits from left to right, so the turtle
+    // should also walk from left to right. The `draw_number` function expects
+    // that it will be drawing rows sixteen bits long, so it needs to move
+    // forward another four bits' worth of space in order to be in the correct
+    // spot.
+    turtle.forward(8.0 * BIT_BOX / 2.0);
+    turtle.forward(16.0 * BIT_BOX / 2.0);
+    // Then, it needs to turn around, to walk in the other direction.
+    turtle.right(180.0);
+
+    draw_number(&mut turtle, NUMBER);
+
+    // Reader exercise:
+    //
+    // The IEEE-754 format for `f64` numbers separates them into three parts:
+    //
+    // 1. The sign marks whether the number is positive or negative: 1 bit
+    // 2. The exponent marks how far from zero the number is: 11 bits
+    // 3. The fraction describes the number: 52 bits.
+    //
+    // Using these widths (1 bit, 11 bits, 52 bits), the knowledge that
+    // `&BitSlice` is a normal Rust slice, and the API documentation for
+    // `std::iter::Iterator`, see if you can display each portion of an `f64`
+    // as its own row.
+    //
+    // Hints:
+    //
+    // - The variable `bits` is set up to view the entire number, from most
+    // significant bit to least.
+    // - You can get access to a structure that performs iteration by calling
+    //   `bits.iter()`.
+    // - You can use the `Iterator::by_ref` method to prevent `Iterator` adapter
+    //   functions from destroying the source iterator.
+    // - `&BitSlice` is an ordinary Rust slice, so you can use `[start .. end]`
+    //   range indexing to get smaller pieces of it.
+}
+
 /// Draws the bits of a text span on the screen.
 fn draw_text(turtle: &mut Turtle, text: &str) {
     // Rust strings can iterate over their individual characters. This block
@@ -125,72 +191,6 @@ fn draw_number(turtle: &mut Turtle, number: f64) {
 
         next_row(turtle, -90.0);
     }
-}
-
-fn main() {
-    // This block sets up the turtle to draw bits more or less centered in the
-    // screen. The turtle works by walking horizontally for each bit in a byte,
-    // then backtracking and walking vertically to the next byte.
-    let mut turtle = Turtle::new();
-    // The turtle starts in the center of the screen, but we want to move it
-    // around before drawing.
-    turtle.pen_up();
-
-    // Compute the boundaries of the part of the screen where the turtle will
-    // draw. We expect to be drawing eight bits, with half to the right of
-    // center and half to the left.
-    let right_edge = BIT_BOX * 8.0 / 2.0;
-    // We also expect to be drawing a row for each byte in the text, with an
-    // additional separator row for each *character*, half above and half below
-    // the center of the screen. This computes how many rows of text we will
-    // draw, then moves the turtle appropriately.
-    let byte_rows = TEXT.len();
-    let char_gaps = TEXT.chars().count();
-    let top_edge = BIT_HEIGHT * ((byte_rows + char_gaps) as f64 / 2.0);
-    // The turtle starts from the top right of the region,
-    turtle.forward(top_edge);
-    turtle.right(90.0);
-    turtle.forward(right_edge);
-    // and walks left
-    turtle.left(180.0);
-
-    draw_text(&mut turtle, TEXT);
-
-    // The `draw_number` function reads bits from left to right, so the turtle
-    // should also walk from left to right. The `draw_number` function expects
-    // that it will be drawing rows sixteen bits long, so it needs to move
-    // forward another four bits' worth of space in order to be in the correct
-    // spot.
-    turtle.forward(8.0 * BIT_BOX / 2.0);
-    turtle.forward(16.0 * BIT_BOX / 2.0);
-    // Then, it needs to turn around, to walk in the other direction.
-    turtle.right(180.0);
-
-    draw_number(&mut turtle, NUMBER);
-
-    // Reader exercise:
-    //
-    // The IEEE-754 format for `f64` numbers separates them into three parts:
-    //
-    // 1. The sign marks whether the number is positive or negative: 1 bit
-    // 2. The exponent marks how far from zero the number is: 11 bits
-    // 3. The fraction describes the number: 52 bits.
-    //
-    // Using these widths (1 bit, 11 bits, 52 bits), the knowledge that
-    // `&BitSlice` is a normal Rust slice, and the API documentation for
-    // `std::iter::Iterator`, see if you can display each portion of an `f64`
-    // as its own row.
-    //
-    // Hints:
-    //
-    // - The variable `bits` is set up to view the entire number, from most
-    // significant bit to least.
-    // - You can get access to a structure that performs iteration by calling
-    //   `bits.iter()`.
-    // - You can use the `Iterator::by_ref` method to prevent `Iterator` adapter
-    //   functions from destroying the source iterator.
-    // - `&BitSlice` is an ordinary Rust slice, so you can use `[start .. end]`
-    //   range indexing to get smaller pieces of it.
 }
 
 /// Draw a row of bits on the screen.

--- a/examples/bits.rs
+++ b/examples/bits.rs
@@ -11,14 +11,32 @@
 
 // The `bitvec` crate provides a lot of types; we only need a few:
 use bitvec::prelude::*;
-    // This trait provides the `.bits::<_>()` method which we use on Rust types
-    // to make `bitvec` views,
 use turtle::Turtle;
 
-/// Set the line length for each displayed bit
+// Modify these constants to change the behavior of the example.
+
+/// This controls the width of the drawn line for each bit.
 const BIT_WIDTH: f64 = 20.0;
-/// Set the vertical spacing between successive rows of bits
+
+/// This controls the vertical spacing between rows of bit lines.
 const BIT_HEIGHT: f64 = 10.0;
+
+/// This text will be inspected as individual bytes, and drawn on the screen.
+/// You can change it to see what different text looks like when viewed as bits.
+///
+/// The example program will print more information about the parts of the text
+/// to the console while the turtle draws, so that you can see how each glyph
+/// corresponds to parts of the rendered memory.
+static TEXT: &str = "¡Hola, mundo! 🌍🌏🌎";
+
+/// This number will have its bit pattern printed on screen. Rust provides some
+/// interesting numbers in its standard library; you can replace this with other
+/// numbers to see what they look like. Pi is provided as the default solely
+/// because it is well-known, and has an interesting pattern.
+const NUMBER: f64 = std::f64::consts::PI;
+
+// These are helpers for the turtle's actions.
+
 /// Set the horizontal spacing between successive bits in a row
 const BIT_MARGIN: f64 = BIT_WIDTH / 2.0;
 /// Compute the total width of a bit plus its spacing
@@ -29,37 +47,36 @@ fn main() {
     // screen. The turtle works by walking horizontally for each bit in a byte,
     // then backtracking and walking vertically to the next byte.
     let mut turtle = Turtle::new();
+    // The turtle starts in the center, but we want to move it around before
+    // drawing.
     turtle.pen_up();
     // Compute the boundaries of the part of the screen where the turtle will
     // draw
     let right_edge = BIT_BOX * 4.0;
-
-    // Now let's draw some data on the screen, as individual bits
-
-    // Replace this text with a message of your own to see how it changes on the
-    // screen.
-    //
-    // Try translating the displayed lines to binary numbers and work out their
-    // encoding!
-    let text = "¡Hola, mundo! 🌍🌏🌎";
-
     // Place the turtle according to the length of the text span
-    let top_edge = BIT_HEIGHT * (text.len() as f64 / 2.0);
+    let top_edge = BIT_HEIGHT * (TEXT.len() as f64 / 2.0);
     // The turtle starts from the top right of the region,
     turtle.go_to((right_edge, top_edge));
     // and walks left
     turtle.set_heading(180.0);
 
+    // Render the text as bits of memory.
+
     // Rust strings can iterate over their individual characters. This block
     // loops over characters, collecting their start point in the text so that
     // we can grab the encoded bytes of each one.
     let mut row_num = 0;
-    for (char_num, (start, codepoint)) in text.char_indices().enumerate() {
+    for (char_num, (start, codepoint)) in TEXT.char_indices().enumerate() {
         println!("Character {}: {}", char_num, codepoint);
         // Each character has a variable width, so we need to find that.
         let byte_count = codepoint.len_utf8();
         // And then collect the bytes of the string that make up the character.
-        let row = &text.as_bytes()[start ..][.. byte_count];
+        // `start` gives us the starting position in the text sequence, and
+        // `byte_count` gives us the length in bytes of the character, so we
+        // need to select the range beginning at `start`, running for
+        // `byte_count`. Another style of writing this that you might see in
+        // Rust libraries is `[start ..][.. length]`.
+        let row: &[u8] = &TEXT.as_bytes()[start .. start + byte_count];
 
         // For each byte (`u8`), we use `bitvec` to make a view into its bits.
         // `bitvec` provides the `.bits::<_>()` method on Rust integers for easy
@@ -77,7 +94,7 @@ fn main() {
         for byte in row {
             println!("  Byte {:02}:\n    Value: 0x{:02X}\n    Bits: {:08b}", row_num, byte, byte);
 
-            let bits = byte.bits::<LittleEndian>();
+            let bits: &BitSlice<_, _> = byte.bits::<LittleEndian>();
 
             // Then we draw the byte's bits as a row
             draw_row(&mut turtle, bits);
@@ -90,11 +107,7 @@ fn main() {
 
     // `bitvec` can look at more than just `u8`. Let's try looking at the bits
     // that represent a number!
-
-    // First we need to pick a number. Rust provides some interesting numbers
-    // for us.
-    let num = std::f64::consts::PI * 2.0;
-
+    //
     // But `bitvec` doesn't know how to view all numbers. The standard library
     // provides a function `to_bits(f64) -> u64`, which turns it into a number
     // `bitvec` does know how to view.
@@ -102,10 +115,10 @@ fn main() {
     // The `f64` data type has a memory encoding standardized by the IEEE-754
     // document. You can read more about it here:
     // https://en.wikipedia.org/wiki/Double-precision_floating-point_format
-    let raw_number = num.to_bits();
+    let raw_number: u64 = NUMBER.to_bits();
 
     // `bitvec` can also view bits from left to right, with `BigEndian`.
-    let bits = raw_number.bits::<BigEndian>();
+    let bits: &BitSlice<_, _> = raw_number.bits::<BigEndian>();
 
     // Since we are reading bits from left to right, the turtle should move from
     // left to right also. Change the `* 2.0` to move the section horizontally.
@@ -127,6 +140,30 @@ fn main() {
         // After each row, the turtle has to go back to the left edge.
         turtle.set_x(left_edge);
     }
+
+    // Reader exercise:
+    //
+    // The IEEE-754 format for `f64` numbers separates them into three parts:
+    //
+    // 1. The sign marks whether the number is positive or negative: 1 bit
+    // 2. The exponent marks how far from zero the number is: 11 bits
+    // 3. The fraction describes the number: 52 bits.
+    //
+    // Using these widths (1 bit, 11 bits, 52 bits), the knowledge that
+    // `&BitSlice` is a normal Rust slice, and the API documentation for
+    // `std::iter::Iterator`, see if you can display each portion of an `f64`
+    // as its own row.
+    //
+    // Hints:
+    //
+    // - The variable `bits` is set up to view the entire number, from most
+    // significant bit to least.
+    // - You can get access to a structure that performs iteration by calling
+    //   `bits.iter()`.
+    // - You can use the `Iterator::by_ref` method to prevent `Iterator` adapter
+    //   functions from destroying the source iterator.
+    // - `&BitSlice` is an ordinary Rust slice, so you can use `[start .. end]`
+    //   range indexing to get smaller pieces of it.
 }
 
 /// Draw a row of bits on the screen.

--- a/examples/bits.rs
+++ b/examples/bits.rs
@@ -25,7 +25,10 @@ const BIT_BOX: f64 = BIT_WIDTH + BIT_MARGIN;
 fn main() {
     // Replace this text with a message of your own to see how it changes on the
     // screen.
-    let text = "Hello, world!";
+    //
+    // Try translating the displayed lines to binary numbers and work out their
+    // encoding!
+    let text = "¡Hola, mundo! 🌍🌏🌎";
 
     // This block sets up the turtle to draw bits more or less centered in the
     // screen. The turtle works by walking horizontally for each bit in a byte,


### PR DESCRIPTION
This PR uses my [`bitvec`](//crates.io/crates/bitvec) crate to view arbitrary memory as sequences of bits, and draws that memory on screen. It provides two examples: a traversal of supra-ASCII text to demonstrate UTF-8 encoding, and a traversal of a `f64` number to demonstrate IEEE-754 encoding.

The example program relies on `bitvec` to map data into `bool` iterators, and focuses solely on displaying memory as bit sequences on screen. It explains the function used to display bits, and marks the locations of easiest alteration for users to see how changing the input data changes the displayed image.

The example program seeks to demonstrate that memory can be traversed in different orders, while printing a consistent most-significant-bit-left view to the screen. This should be a fair compromise between remaining consistent with user expectations about directionality (presuming they are conditioned to an LTR writing system) and demonstration that directionality can be chosen as needed.