### PR TITLE
Export color constants as associated constants on Color

### DIFF
--- a/examples/draw_turtle.rs
+++ b/examples/draw_turtle.rs
@@ -5,7 +5,7 @@
 //! To draw arcs, we use multiple Rust for-loops to create different tilt angles and
 //! lengths. The more sophisticated the figure is, the more loops we need to make it.
 
-use turtle::{color, Color, Drawing, Turtle};
+use turtle::{Color, Drawing, Turtle};
 
 const SIZE: f64 = 1.0;
 const SHELL_COLOR: Color = Color {
@@ -20,7 +20,7 @@ const BODY_COLOR: Color = Color {
     blue: 85.0,
     alpha: 1.0,
 };
-const EYE_COLOR: Color = color::BLACK;
+const EYE_COLOR: Color = Color::BLACK;
 
 fn main() {
     let mut drawing = Drawing::new();

--- a/src/color.rs
+++ b/src/color.rs
@@ -2371,21 +2371,9 @@ pub mod extended {
     use super::Color;
 
     color_consts! {
-        "grey", GREY, (146.0, 149.0, 145.0, 1.0);
         "sky blue", SKY_BLUE, (117.0, 187.0, 253.0, 1.0);
-        "yellow", YELLOW, (255.0, 255.0, 20.0, 1.0);
-        "magenta", MAGENTA, (194.0, 0.0, 120.0, 1.0);
         "light green", LIGHT_GREEN, (150.0, 249.0, 123.0, 1.0);
-        "orange", ORANGE, (249.0, 115.0, 6.0, 1.0);
-        "teal", TEAL, (2.0, 147.0, 134.0, 1.0);
         "light blue", LIGHT_BLUE, (149.0, 208.0, 252.0, 1.0);
-        "red", RED, (229.0, 0.0, 0.0, 1.0);
-        "brown", BROWN, (101.0, 55.0, 0.0, 1.0);
-        "pink", PINK, (255.0, 129.0, 192.0, 1.0);
-        "blue", BLUE, (3.0, 67.0, 223.0, 1.0);
-        "green", GREEN, (21.0, 176.0, 26.0, 1.0);
-        "purple", PURPLE, (126.0, 30.0, 156.0, 1.0);
-
         "cloudy blue", CLOUDY_BLUE, (172.0, 194.0, 217.0, 1.0);
         "dark pastel green", DARK_PASTEL_GREEN, (86.0, 174.0, 87.0, 1.0);
         "dust", DUST, (178.0, 153.0, 110.0, 1.0);
@@ -3199,7 +3187,6 @@ pub mod extended {
         "dark magenta", DARK_MAGENTA, (150.0, 0.0, 86.0, 1.0);
         "greenish", GREENISH, (64.0, 163.0, 104.0, 1.0);
         "ocean blue", OCEAN_BLUE, (3.0, 113.0, 156.0, 1.0);
-        "coral", CORAL, (252.0, 90.0, 80.0, 1.0);
         "cream", CREAM, (255.0, 255.0, 194.0, 1.0);
         "reddish brown", REDDISH_BROWN, (127.0, 43.0, 10.0, 1.0);
         "burnt sienna", BURNT_SIENNA, (176.0, 78.0, 15.0, 1.0);
@@ -3243,7 +3230,6 @@ pub mod extended {
         "dark orange", DARK_ORANGE, (198.0, 81.0, 2.0, 1.0);
         "sand", SAND, (226.0, 202.0, 118.0, 1.0);
         "pastel green", PASTEL_GREEN, (176.0, 255.0, 157.0, 1.0);
-        "mint", MINT, (159.0, 254.0, 176.0, 1.0);
         "light orange", LIGHT_ORANGE, (253.0, 170.0, 72.0, 1.0);
         "bright pink", BRIGHT_PINK, (254.0, 1.0, 177.0, 1.0);
         "chartreuse", CHARTREUSE, (193.0, 248.0, 10.0, 1.0);
@@ -3269,7 +3255,6 @@ pub mod extended {
         "dark red", DARK_RED, (132.0, 0.0, 0.0, 1.0);
         "pale blue", PALE_BLUE, (208.0, 254.0, 254.0, 1.0);
         "grass green", GRASS_GREEN, (63.0, 155.0, 11.0, 1.0);
-        "navy", NAVY, (1.0, 21.0, 62.0, 1.0);
         "aquamarine", AQUAMARINE, (4.0, 216.0, 178.0, 1.0);
         "burnt orange", BURNT_ORANGE, (192.0, 78.0, 1.0, 1.0);
         "neon green", NEON_GREEN, (12.0, 255.0, 12.0, 1.0);
@@ -3278,7 +3263,6 @@ pub mod extended {
         "light pink", LIGHT_PINK, (255.0, 209.0, 223.0, 1.0);
         "mustard", MUSTARD, (206.0, 179.0, 1.0, 1.0);
         "indigo", INDIGO, (56.0, 2.0, 130.0, 1.0);
-        "lime", LIME, (170.0, 255.0, 50.0, 1.0);
         "sea green", SEA_GREEN, (83.0, 252.0, 161.0, 1.0);
         "periwinkle", PERIWINKLE, (142.0, 130.0, 254.0, 1.0);
         "dark pink", DARK_PINK, (203.0, 65.0, 107.0, 1.0);
@@ -3290,19 +3274,14 @@ pub mod extended {
         "lilac", LILAC, (206.0, 162.0, 253.0, 1.0);
         "navy blue", NAVY_BLUE, (0.0, 17.0, 70.0, 1.0);
         "royal blue", ROYAL_BLUE, (5.0, 4.0, 170.0, 1.0);
-        "beige", BEIGE, (230.0, 218.0, 166.0, 1.0);
         "salmon", SALMON, (255.0, 121.0, 108.0, 1.0);
-        "olive", OLIVE, (110.0, 117.0, 14.0, 1.0);
-        "maroon", MAROON, (101.0, 0.0, 33.0, 1.0);
         "bright green", BRIGHT_GREEN, (1.0, 255.0, 7.0, 1.0);
         "dark purple", DARK_PURPLE, (53.0, 6.0, 62.0, 1.0);
         "mauve", MAUVE, (174.0, 113.0, 129.0, 1.0);
         "forest green", FOREST_GREEN, (6.0, 71.0, 12.0, 1.0);
         "aqua", AQUA, (19.0, 234.0, 201.0, 1.0);
-        "cyan", CYAN, (0.0, 255.0, 255.0, 1.0);
         "tan", TAN, (209.0, 178.0, 111.0, 1.0);
         "dark blue", DARK_BLUE, (0.0, 3.0, 91.0, 1.0);
-        "lavender", LAVENDER, (199.0, 159.0, 239.0, 1.0);
         "turquoise", TURQUOISE, (6.0, 194.0, 172.0, 1.0);
         "dark green", DARK_GREEN, (3.0, 53.0, 0.0, 1.0);
         "violet", VIOLET, (154.0, 14.0, 234.0, 1.0);

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,162 +1,3 @@
-//! Color types and constants
-//!
-//! When setting a color, you can use a variety of different color names.
-//! This module contains many of the most common colors that you might want to use. There is an
-//! even more comprehensive list in the [`extended`](extended/index.html) module. Any of the color names
-//! listed in this module or in the `extended` module can be used as a color. You only need to
-//! reference the `color::extended` module if you want to use a specific color constant from that
-//! module.
-//!
-//! You can refer to a color by using its color name as a string literal. For example:
-//!
-//! ```rust
-//! # use turtle::Color;
-//! # let mut turtle = turtle::Turtle::new();
-//! // This will set the turtle's pen color to BLACK
-//! turtle.set_pen_color("black");
-//! // This is the same as the previous line
-//! turtle.set_pen_color(Color::BLACK);
-//! // You can use any of the supported color names (including the ones from extended)
-//! turtle.set_pen_color("deep lilac");
-//! ```
-//!
-//! You can also use hexadecimal color strings to get any color you want
-//! (even ones that aren't listed here).
-//!
-//! ```rust
-//! # let mut turtle = turtle::Turtle::new();
-//! turtle.set_pen_color("#3366ff");
-//! turtle.set_pen_color("#36f");
-//! ```
-//!
-//! Each color's constant name is in uppercase in the list below. The color name you should use to
-//! refer to it is in lower case next to the constant.
-//!
-//! For your convenience, there are two static variables [`COLORS`](static.COLORS.html) and
-//! [`COLOR_NAMES`](static.COLOR_NAMES.html) which contain the values of all the color constants
-//! and each of their names as strings. These static variables only contain the colors from this
-//! module. The [`extended`](extended/index.html) module has its own static `COLOR` and
-//! `COLOR_NAMES` variables.
-//!
-//! # Random Colors
-//!
-//! You can also generate random colors. Here's an example:
-//!
-//! ```rust
-//! # let mut turtle = turtle::Turtle::new();
-//! use turtle::{rand::random, Color};
-//! turtle.set_pen_color(random::<Color>().opaque());
-//! ```
-//!
-//! The syntax used in `random::<Color>()` is referred to as
-//! ["turbofish" syntax](https://doc.rust-lang.org/book/first-edition/generics.html#resolving-ambiguities).
-//! See that documentation for more information.
-//!
-//! Notice that you need to explicitly call the [`opaque()`](struct.Color.html#method.opaque)
-//! method on the color in order to make sure that the color has an alpha value of 1.0. By default,
-//! when you generate a random color, it's alpha value will be random as well.
-//!
-//! See the [examples directory on GitHub](https://github.com/sunjay/turtle/tree/master/examples)
-//! for more information.
-//!
-//! # Creating a Color from Values
-//!
-//! Usually, you won't need to initialize a color this way since the above methods are quite
-//! convenient. However, in some situations it may be necessary to create a color with specific
-//! red, green, and blue values. The following example illustrates how to do that.
-//!
-//! ```rust
-//! use turtle::Color;
-//! let my_color = Color {red: 255.0, green: 55.0, blue: 11.0, alpha: 1.0};
-//! ```
-//!
-//! Note that when creating a color this way, we **do not** check if the values of each property are
-//! within their valid ranges.
-//!
-//!
-//! Another ergonomic syntax can also be used when passing a color to a method that supports any
-//! type that implements `Into<Color>`.
-//!
-//! ```rust
-//! # use turtle::*;
-//! let mut drawing = Drawing::new();
-//! let mut turtle = drawing.add_turtle();
-//!
-//! // A solid color with alpha = 1.0
-//! // Syntax is [red, green, blue] and doesn't require explicitly writing the field names
-//! turtle.set_pen_color([133.0, 23.0, 96.0]);
-//! turtle.set_fill_color([133.0, 23.0, 96.0]);
-//! drawing.set_background_color([133.0, 23.0, 96.0]);
-//! // This is a little easier to type than the equivalent:
-//! drawing.set_background_color(Color {red: 133.0, green: 23.0, blue: 96.0, alpha: 1.0});
-//!
-//! // Add an additional element to the array to specify the alpha
-//! // Syntax is [red, green, blue, alpha]
-//! turtle.set_pen_color([133.0, 23.0, 96.0, 0.5]);
-//! turtle.set_fill_color([133.0, 23.0, 96.0, 0.5]);
-//! drawing.set_background_color([133.0, 23.0, 96.0, 0.5]);
-//! // This is a little easier to type than the equivalent:
-//! drawing.set_background_color(Color {red: 133.0, green: 23.0, blue: 96.0, alpha: 0.5});
-//! ```
-//!
-//! When creating a color this way, we **will** check whether or not the color is valid and provide
-//! an error message to let you know what happened.
-//!
-//! ```rust,should_panic
-//! # let mut turtle = turtle::Turtle::new();
-//! // Color values must only go up to 255.0
-//! turtle.set_pen_color([133.0, 256.0, 96.0]); // This will panic with an error message
-//! ```
-//! There are also constructor methods available for `Color` that allow you to create a new
-//! color using provided values. These are:
-//!
-//! * [`rgb(red, green, blue)`]: Create from the given red, green, and blue values with an alpha value of 1.0
-//! * [`rgba(red, green, blue, alpha)`]: Similar to `rgb` but also accepts an alpha value
-//! * [`hsl(hue, saturation, lightness)`]: Create from the given hue, saturation, and lightness values with an alpha of 1.0
-//! * [`hsla(hue, saturation, lightness, alpha)`]: Similar to `hsl` but also accepts an alpha value
-//!
-//! These methods provide a concise syntax for creating a new `Color`. If the values passed in are invalid,
-//! the program will exit with an error that lets you know what happened. See the documentation for each
-//! method (linked above) to see which values are correct for each parameter.
-//!
-//! ```rust
-//! use turtle::Color;
-//!
-//! // These are equivalent
-//! let white_manual = Color { red: 255.0, green: 255.0, blue: 255.0, alpha: 1.0 };
-//! let white_rgb = Color::rgb(255.0, 255.0, 255.0);
-//! let white_rgba = Color::rgba(255.0, 255.0, 255.0, 1.0);
-//! let white_hsl = Color::hsl(0.0, 0.0, 1.0);
-//! let white_hsla = Color::hsla(0.0, 0.0, 1.0, 1.0);
-//!
-//! assert_eq!(white_manual, white_rgb);
-//! assert_eq!(white_rgb, white_rgba);
-//! assert_eq!(white_rgba, white_hsl);
-//! assert_eq!(white_hsl, white_hsla);
-//! ```
-//!
-//! So, you can incorporate these constructors into your turtle code along with
-//! other methods of color creation if you like:
-//!
-//! ```rust
-//! # use turtle::*;
-//! let mut drawing = Drawing::new();
-//! let mut turtle = drawing.add_turtle();
-//!
-//! // Set the pen color to blue
-//! turtle.set_pen_color(Color::rgb(0.0, 130.0, 200.0));
-//!
-//! // And the same color can be set for the fill color via the array syntax.
-//! turtle.set_fill_color([0.0, 130.0, 200.0]);
-//!
-//! // Then, we can set the background to black
-//! drawing.set_background_color("black");
-//! ```
-//! [`rgb(red, green, blue)`]: ./struct.Color.html#method.rgb
-//! [`rgba(red, green, blue, alpha)`]: ./struct.Color.html#method.rgba
-//! [`hsl(hue, saturation, lightness)`]: ./struct.Color.html#method.hsl
-//! [`hsla(hue, saturation, lightness, alpha)`]: ./struct.Color.html#method.hsla
-
 use std::fmt::Debug;
 use std::iter::repeat;
 use std::f64::EPSILON;
@@ -209,7 +50,164 @@ fn f64_eq(left: f64, right: f64) -> bool {
 
 /// Type for representing a color.
 ///
-/// See [the module level documentation](index.html) for more.
+/// Color types and constants
+///
+/// When setting a color, you can use a variety of different color names.
+/// This module contains many of the most common colors that you might want to use. There is an
+/// even more comprehensive list in the [`extended`](extended/index.html) module. Any of the color names
+/// listed in this module or in the `extended` module can be used as a color. You only need to
+/// reference the `color::extended` module if you want to use a specific color constant from that
+/// module.
+///
+/// You can refer to a color by using its color name as a string literal. For example:
+///
+/// ```rust
+/// # use turtle::Color;
+/// # let mut turtle = turtle::Turtle::new();
+/// // This will set the turtle's pen color to BLACK
+/// turtle.set_pen_color("black");
+/// // This is the same as the previous line
+/// turtle.set_pen_color(Color::BLACK);
+/// // You can use any of the supported color names (including the ones from extended)
+/// turtle.set_pen_color("deep lilac");
+/// ```
+///
+/// You can also use hexadecimal color strings to get any color you want
+/// (even ones that aren't listed here).
+///
+/// ```rust
+/// # let mut turtle = turtle::Turtle::new();
+/// turtle.set_pen_color("#3366ff");
+/// turtle.set_pen_color("#36f");
+/// ```
+///
+/// Each color's constant name is in uppercase in the list below. The color name you should use to
+/// refer to it is in lower case next to the constant.
+///
+/// For your convenience, there are two static variables [`COLORS`](static.COLORS.html) and
+/// [`COLOR_NAMES`](static.COLOR_NAMES.html) which contain the values of all the color constants
+/// and each of their names as strings. These static variables only contain the colors from this
+/// module. The [`extended`](extended/index.html) module has its own static `COLOR` and
+/// `COLOR_NAMES` variables.
+///
+/// # Random Colors
+///
+/// You can also generate random colors. Here's an example:
+///
+/// ```rust
+/// # let mut turtle = turtle::Turtle::new();
+/// use turtle::{rand::random, Color};
+/// turtle.set_pen_color(random::<Color>().opaque());
+/// ```
+///
+/// The syntax used in `random::<Color>()` is referred to as
+/// ["turbofish" syntax](https://doc.rust-lang.org/book/first-edition/generics.html#resolving-ambiguities).
+/// See that documentation for more information.
+///
+/// Notice that you need to explicitly call the [`opaque()`](struct.Color.html#method.opaque)
+/// method on the color in order to make sure that the color has an alpha value of 1.0. By default,
+/// when you generate a random color, it's alpha value will be random as well.
+///
+/// See the [examples directory on GitHub](https://github.com/sunjay/turtle/tree/master/examples)
+/// for more information.
+///
+/// # Creating a Color from Values
+///
+/// Usually, you won't need to initialize a color this way since the above methods are quite
+/// convenient. However, in some situations it may be necessary to create a color with specific
+/// red, green, and blue values. The following example illustrates how to do that.
+///
+/// ```rust
+/// use turtle::Color;
+/// let my_color = Color {red: 255.0, green: 55.0, blue: 11.0, alpha: 1.0};
+/// ```
+///
+/// Note that when creating a color this way, we **do not** check if the values of each property are
+/// within their valid ranges.
+///
+///
+/// Another ergonomic syntax can also be used when passing a color to a method that supports any
+/// type that implements `Into<Color>`.
+///
+/// ```rust
+/// # use turtle::*;
+/// let mut drawing = Drawing::new();
+/// let mut turtle = drawing.add_turtle();
+///
+/// // A solid color with alpha = 1.0
+/// // Syntax is [red, green, blue] and doesn't require explicitly writing the field names
+/// turtle.set_pen_color([133.0, 23.0, 96.0]);
+/// turtle.set_fill_color([133.0, 23.0, 96.0]);
+/// drawing.set_background_color([133.0, 23.0, 96.0]);
+/// // This is a little easier to type than the equivalent:
+/// drawing.set_background_color(Color {red: 133.0, green: 23.0, blue: 96.0, alpha: 1.0});
+///
+/// // Add an additional element to the array to specify the alpha
+/// // Syntax is [red, green, blue, alpha]
+/// turtle.set_pen_color([133.0, 23.0, 96.0, 0.5]);
+/// turtle.set_fill_color([133.0, 23.0, 96.0, 0.5]);
+/// drawing.set_background_color([133.0, 23.0, 96.0, 0.5]);
+/// // This is a little easier to type than the equivalent:
+/// drawing.set_background_color(Color {red: 133.0, green: 23.0, blue: 96.0, alpha: 0.5});
+/// ```
+///
+/// When creating a color this way, we **will** check whether or not the color is valid and provide
+/// an error message to let you know what happened.
+///
+/// ```rust,should_panic
+/// # let mut turtle = turtle::Turtle::new();
+/// // Color values must only go up to 255.0
+/// turtle.set_pen_color([133.0, 256.0, 96.0]); // This will panic with an error message
+/// ```
+/// There are also constructor methods available for `Color` that allow you to create a new
+/// color using provided values. These are:
+///
+/// * [`rgb(red, green, blue)`]: Create from the given red, green, and blue values with an alpha value of 1.0
+/// * [`rgba(red, green, blue, alpha)`]: Similar to `rgb` but also accepts an alpha value
+/// * [`hsl(hue, saturation, lightness)`]: Create from the given hue, saturation, and lightness values with an alpha of 1.0
+/// * [`hsla(hue, saturation, lightness, alpha)`]: Similar to `hsl` but also accepts an alpha value
+///
+/// These methods provide a concise syntax for creating a new `Color`. If the values passed in are invalid,
+/// the program will exit with an error that lets you know what happened. See the documentation for each
+/// method (linked above) to see which values are correct for each parameter.
+///
+/// ```rust
+/// use turtle::Color;
+///
+/// // These are equivalent
+/// let white_manual = Color { red: 255.0, green: 255.0, blue: 255.0, alpha: 1.0 };
+/// let white_rgb = Color::rgb(255.0, 255.0, 255.0);
+/// let white_rgba = Color::rgba(255.0, 255.0, 255.0, 1.0);
+/// let white_hsl = Color::hsl(0.0, 0.0, 1.0);
+/// let white_hsla = Color::hsla(0.0, 0.0, 1.0, 1.0);
+///
+/// assert_eq!(white_manual, white_rgb);
+/// assert_eq!(white_rgb, white_rgba);
+/// assert_eq!(white_rgba, white_hsl);
+/// assert_eq!(white_hsl, white_hsla);
+/// ```
+///
+/// So, you can incorporate these constructors into your turtle code along with
+/// other methods of color creation if you like:
+///
+/// ```rust
+/// # use turtle::*;
+/// let mut drawing = Drawing::new();
+/// let mut turtle = drawing.add_turtle();
+///
+/// // Set the pen color to blue
+/// turtle.set_pen_color(Color::rgb(0.0, 130.0, 200.0));
+///
+/// // And the same color can be set for the fill color via the array syntax.
+/// turtle.set_fill_color([0.0, 130.0, 200.0]);
+///
+/// // Then, we can set the background to black
+/// drawing.set_background_color("black");
+/// ```
+/// [`rgb(red, green, blue)`]: ./struct.Color.html#method.rgb
+/// [`rgba(red, green, blue, alpha)`]: ./struct.Color.html#method.rgba
+/// [`hsl(hue, saturation, lightness)`]: ./struct.Color.html#method.hsl
+/// [`hsla(hue, saturation, lightness, alpha)`]: ./struct.Color.html#method.hsla
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct Color {
     /// Value between 0.0 and 255.0

--- a/src/color.rs
+++ b/src/color.rs
@@ -2370,6 +2370,29 @@ pub mod extended {
     //! module.
     use super::Color;
 
+    macro_rules! color_consts {
+        ($($name:expr, $id:ident, ($r:expr, $g:expr, $b:expr, $a:expr);)*) => {
+            $(
+                #[doc = $name]
+                pub const $id: Color = Color {red: $r, green: $g, blue: $b, alpha: $a};
+            )*
+
+            /// A list of all of the colors
+            pub static COLORS: &[Color] = &[$($id, )*];
+            /// A list of all of the color names
+            pub static COLOR_NAMES: &[&str] = &[$($name, )*];
+
+            pub(crate) fn from_color_name(s: &str) -> Option<Color> {
+                match s {
+                    $(
+                        $name => Some($id),
+                    )*
+                    _ => None,
+                }
+            }
+        }
+    }
+
     color_consts! {
         "sky blue", SKY_BLUE, (117.0, 187.0, 253.0, 1.0);
         "light green", LIGHT_GREEN, (150.0, 249.0, 123.0, 1.0);

--- a/src/color.rs
+++ b/src/color.rs
@@ -1189,15 +1189,15 @@ impl<'a> From<&'a str> for Color {
 
 macro_rules! color_consts {
     ($($name:expr, $id:ident, ($r:expr, $g:expr, $b:expr, $a:expr);)*) => {
-        $(
-            #[doc = $name]
-            pub const $id: Color = Color {red: $r, green: $g, blue: $b, alpha: $a};
-        )*
-
         impl Color {
+            $(
+                #[doc = $name]
+                pub const $id: Color = Color {red: $r, green: $g, blue: $b, alpha: $a};
+            )*
+
             /// Return a list of all of the colors.
             pub fn all_colors() -> &'static [Color] {
-                &[$($id, )*]
+                &[$(Color::$id, )*]
             }
 
             /// Return a list of all of the color names.
@@ -1209,7 +1209,7 @@ macro_rules! color_consts {
         pub(crate) fn from_color_name(s: &str) -> Option<Color> {
             match s {
                 $(
-                    $name => Some($id),
+                    $name => Some(Color::$id),
                 )*
                 _ => None,
             }

--- a/src/color.rs
+++ b/src/color.rs
@@ -1194,10 +1194,17 @@ macro_rules! color_consts {
             pub const $id: Color = Color {red: $r, green: $g, blue: $b, alpha: $a};
         )*
 
-        /// A list of all of the colors
-        pub static COLORS: &[Color] = &[$($id, )*];
-        /// A list of all of the color names
-        pub static COLOR_NAMES: &[&str] = &[$($name, )*];
+        impl Color {
+            /// Return a list of all of the colors.
+            pub fn all_colors() -> &'static [Color] {
+                &[$($id, )*]
+            }
+
+            /// Return a list of all of the color names.
+            pub fn all_color_names() -> &'static [&'static str] {
+                &[$($name, )*]
+            }
+        }
 
         pub(crate) fn from_color_name(s: &str) -> Option<Color> {
             match s {

--- a/src/color.rs
+++ b/src/color.rs
@@ -10,12 +10,12 @@
 //! You can refer to a color by using its color name as a string literal. For example:
 //!
 //! ```rust
-//! # use turtle::color;
+//! # use turtle::Color;
 //! # let mut turtle = turtle::Turtle::new();
 //! // This will set the turtle's pen color to BLACK
 //! turtle.set_pen_color("black");
 //! // This is the same as the previous line
-//! turtle.set_pen_color(color::BLACK);
+//! turtle.set_pen_color(Color::BLACK);
 //! // You can use any of the supported color names (including the ones from extended)
 //! turtle.set_pen_color("deep lilac");
 //! ```
@@ -326,7 +326,7 @@ impl Color {
     /// * 0.0 &le; `alpha` &le; 1.0
     ///
     /// ```rust
-    /// use turtle::{Color, color};
+    /// use turtle::Color;
     ///
     /// // You can chain using Color::from()
     /// let black = Color::from("black").with_alpha(0.5);
@@ -335,11 +335,11 @@ impl Color {
     ///
     /// // But even better, you can use the color enum value and chain the
     /// // calls.
-    /// let white = color::WHITE.with_alpha(0.75);
+    /// let white = Color::WHITE.with_alpha(0.75);
     /// let white_hsla = Color::hsla(0.0, 1.0, 1.0, 0.75);
     /// assert_eq!(white, white_hsla);
     ///
-    /// let blue: Color = color::BLUE.with_alpha(0.8);
+    /// let blue: Color = Color::BLUE.with_alpha(0.8);
     /// let blue_hsla = Color::hsla(201.0, 1.0, 0.392, 0.8);
     /// assert_eq!(blue, blue_hsla);
     /// ```
@@ -484,12 +484,12 @@ impl Color {
     /// Passing a value for `weight` that is not between 0.0 and 1.0 will result in a `panic`
     ///
     /// ```should_panic
-    /// use turtle::{Color, color};
+    /// use turtle::Color;
     ///
     /// let orange: Color = "orange".into();
     ///
     /// // This will panic as 1.01 is not a valid value for weight, which must be between 0.0 and 1.0.
-    /// let mixed = orange.mix(color::BROWN.with_alpha(0.8), 1.01);
+    /// let mixed = orange.mix(Color::BROWN.with_alpha(0.8), 1.01);
     /// ```
     ///
     /// # Example

--- a/src/color.rs
+++ b/src/color.rs
@@ -50,13 +50,13 @@ fn f64_eq(left: f64, right: f64) -> bool {
 
 /// Type for representing a color.
 ///
-/// Color types and constants
+/// # Color types and constants
 ///
 /// When setting a color, you can use a variety of different color names.
 /// This module contains many of the most common colors that you might want to use. There is an
-/// even more comprehensive list in the [`extended`](extended/index.html) module. Any of the color names
-/// listed in this module or in the `extended` module can be used as a color. You only need to
-/// reference the `color::extended` module if you want to use a specific color constant from that
+/// even more comprehensive list in the [`extra_colors`](extra_colors/index.html) module. Any of the color names
+/// listed in this module or in the `extra_colors` module can be used as a color. You only need to
+/// reference the `extra_colors` module if you want to use a specific color constant from that
 /// module.
 ///
 /// You can refer to a color by using its color name as a string literal. For example:
@@ -87,7 +87,7 @@ fn f64_eq(left: f64, right: f64) -> bool {
 /// For your convenience, there are two static variables [`COLORS`](static.COLORS.html) and
 /// [`COLOR_NAMES`](static.COLOR_NAMES.html) which contain the values of all the color constants
 /// and each of their names as strings. These static variables only contain the colors from this
-/// module. The [`extended`](extended/index.html) module has its own static `COLOR` and
+/// module. The [`extra_colors`](extra_colors/index.html) module has its own static `COLOR` and
 /// `COLOR_NAMES` variables.
 ///
 /// # Random Colors

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -165,7 +165,7 @@ impl Drawing {
     /// assert_eq!(drawing.background_color(), "purple".into());
     /// ```
     ///
-    /// See the [`color` module](color/index.html) for more information about colors.
+    /// See the [`Color` struct](struct.Color.html) for more information about colors.
     pub fn background_color(&self) -> Color {
         block_on(self.drawing.background_color())
     }
@@ -173,7 +173,7 @@ impl Drawing {
     /// Sets the color of the background to the given color.
     ///
     /// Any type that can be converted into a color can be passed into this function.
-    /// See the [`color` module](color/index.html) for more information.
+    /// See the [`Color` struct](struct.Color.html) for more information.
     ///
     /// # Example
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!   turtle supports
 //! * The [`Drawing` struct](struct.Drawing.html) - allows you to manipulate the title, size,
 //!   background and more of the drawing that you are creating
-//! * The [`color` module](color/index.html) - describes the different ways to create colors and
+//! * The [`Color` struct](struct.Color.html) - describes the different ways to create colors and
 //!   includes a list of the hundreds of predefined color names that you can use to easily set the
 //!   pen, fill, and background color of your drawings
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ compile_error!("Make sure you run tests with `cargo test --features \"test unsta
 mod radians;
 mod point;
 mod speed;
-pub mod color;
+mod color;
 pub mod rand;
 
 mod ipc_protocol;
@@ -99,6 +99,7 @@ mod drawing;
 mod turtle;
 
 pub use crate::color::Color;
+pub use crate::color::extended as extra_colors;
 pub use crate::async_drawing::Size;
 pub use crate::drawing::Drawing;
 pub use crate::point::Point;

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -557,14 +557,14 @@ impl_random_slice!(32, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, 
 /// # Example
 ///
 /// ```rust,no_run
-/// use turtle::{color, rand::shuffle};
+/// use turtle::{Color, rand::shuffle};
 ///
-/// let mut pen_colors = [color::RED, color::BLUE, color::GREEN, color::YELLOW];
+/// let mut pen_colors = [Color::RED, Color::BLUE, Color::GREEN, Color::YELLOW];
 /// // A different order of colors every time!
 /// shuffle(&mut pen_colors);
 ///
 /// // Even works with Vec
-/// let mut pen_colors = vec![color::RED, color::BLUE, color::GREEN, color::YELLOW];
+/// let mut pen_colors = vec![Color::RED, Color::BLUE, Color::GREEN, Color::YELLOW];
 /// shuffle(&mut pen_colors);
 /// ```
 pub fn shuffle<S: RandomSlice>(slice: &mut S) {
@@ -578,17 +578,17 @@ pub fn shuffle<S: RandomSlice>(slice: &mut S) {
 /// # Example
 ///
 /// ```rust,no_run
-/// use turtle::{Turtle, color, rand::choose};
+/// use turtle::{Turtle, Color, rand::choose};
 ///
 /// let mut turtle = Turtle::new();
 ///
-/// let mut pen_colors = [color::RED, color::BLUE, color::GREEN, color::YELLOW];
+/// let mut pen_colors = [Color::RED, Color::BLUE, Color::GREEN, Color::YELLOW];
 /// // Choose a random pen color
 /// let chosen_color = choose(&mut pen_colors).cloned().unwrap();
 /// turtle.set_pen_color(chosen_color);
 ///
 /// // Even works with Vec
-/// let mut pen_colors = vec![color::RED, color::BLUE, color::GREEN, color::YELLOW];
+/// let mut pen_colors = vec![Color::RED, Color::BLUE, Color::GREEN, Color::YELLOW];
 /// let chosen_color = choose(&mut pen_colors).cloned().unwrap();
 /// turtle.set_pen_color(chosen_color);
 /// ```

--- a/src/renderer_server/state.rs
+++ b/src/renderer_server/state.rs
@@ -3,7 +3,7 @@ use std::f64::consts::PI;
 use serde::{Serialize, Deserialize};
 
 use crate::radians::Radians;
-use crate::{color, Color, Point, Speed};
+use crate::{Color, Point, Speed};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DrawingState {
@@ -18,7 +18,7 @@ pub struct DrawingState {
 
 impl DrawingState {
     pub const DEFAULT_TITLE: &'static str = "Turtle";
-    pub const DEFAULT_BACKGROUND: Color = color::WHITE;
+    pub const DEFAULT_BACKGROUND: Color = Color::WHITE;
     pub const DEFAULT_CENTER: Point = Point::origin();
     pub const DEFAULT_WIDTH: u32 = 800;
     pub const DEFAULT_HEIGHT: u32 = 600;
@@ -51,7 +51,7 @@ pub struct TurtleState {
 }
 
 impl TurtleState {
-    pub const DEFAULT_FILL_COLOR: Color = color::BLACK;
+    pub const DEFAULT_FILL_COLOR: Color = Color::BLACK;
     pub const DEFAULT_POSITION: Point = Point::origin();
     pub const DEFAULT_HEADING: Radians = Radians::from_radians_value(PI / 2.0);
     pub const DEFAULT_IS_VISIBLE: bool = true;
@@ -80,7 +80,7 @@ pub struct Pen {
 impl Pen {
     pub const DEFAULT_IS_ENABLED: bool = true;
     pub const DEFAULT_THICKNESS: f64 = 1.0;
-    pub const DEFAULT_COLOR: Color = color::BLACK;
+    pub const DEFAULT_COLOR: Color = Color::BLACK;
 }
 
 impl Default for Pen {

--- a/src/turtle.rs
+++ b/src/turtle.rs
@@ -630,7 +630,7 @@ impl Turtle {
     /// assert_eq!(turtle.pen_color(), "blue".into());
     /// ```
     ///
-    /// See the [`color` module](color/index.html) for more information about colors.
+    /// See the [`Color` struct](struct.Color.html) for more information about colors.
     pub fn pen_color(&self) -> Color {
         block_on(self.turtle.pen_color())
     }
@@ -638,7 +638,7 @@ impl Turtle {
     /// Sets the color of the pen to the given color.
     ///
     /// Any type that can be converted into a color can be passed into this function.
-    /// See the [`color` module](color/index.html) for more information.
+    /// See the [`Color` struct](struct.Color.html) for more information.
     ///
     /// # Example
     ///
@@ -681,7 +681,7 @@ impl Turtle {
     /// assert_eq!(turtle.fill_color(), "coral".into());
     /// ```
     ///
-    /// See the [`color` module](color/index.html) for more information about colors.
+    /// See the [`Color` struct](struct.Color.html) for more information about colors.
     pub fn fill_color(&self) -> Color {
         block_on(self.turtle.fill_color())
     }
@@ -689,7 +689,7 @@ impl Turtle {
     /// Sets the fill color to the given color.
     ///
     /// Any type that can be converted into a color can be passed into this function.
-    /// See the [`color` module](color/index.html) for more information.
+    /// See the [`Color` struct](struct.Color.html) for more information.
     ///
     /// **Note:** Changing the fill color after calling `begin_fill` will cause the filled shape to
     /// update to the new color.


### PR DESCRIPTION
Fixes #171.

Some notes:

* As we discussed in the issue, I replaced the static variables `COLORS` and `COLOR_NAMES` with the functions `all_colors` and `all_color_names`, respectively. If we keep the `extended` (now `extra_colors` module) we should probably do the same thing there so that it's consistent? (In any case, the documentation should be updated to refer to the functions instead of the static variables.)
* The generated documentation for associated constants is not as compact as the one for module-level constants. I think we could maybe remove the line `#[doc = $name]` in `color_consts!` as this does not provide any more information about the respective constant (other than repeating the name of the color it refers to). This would safe some of the space that the constants take up in the docs.