### PR TITLE
Added the arc method to turtle with two examples

### DIFF
--- a/examples/beats.rs
+++ b/examples/beats.rs
@@ -1,0 +1,43 @@
+extern crate turtle;
+use turtle::{Point, Turtle};
+
+fn main() {
+    let mut turtle = Turtle::new();
+    let init_pos: Point = turtle.position();
+
+    let _radius_outer = 250.0;
+    turtle.set_pen_color("#fe0000");
+    turtle.pen_up();
+    turtle.go_to((init_pos.x - (_radius_outer), init_pos.y));
+    turtle.pen_down();
+    turtle.set_fill_color("#fe0000");
+    turtle.begin_fill();
+    turtle.arc(_radius_outer, None, None);
+    turtle.end_fill();
+
+    let _radius_mid = 115.0;
+    turtle.pen_up();
+    turtle.go_to((init_pos.x.round() - (_radius_mid), init_pos.y));
+    turtle.pen_down();
+    turtle.set_fill_color("white");
+    turtle.set_pen_color("white");
+    turtle.begin_fill();
+    turtle.arc(_radius_mid, None, None);
+    turtle.end_fill();
+
+    let _radius_inner = 60.0;
+    turtle.pen_up();
+    turtle.go_to((init_pos.x - (_radius_inner), init_pos.y));
+    turtle.pen_down();
+    turtle.set_fill_color("#fe0000");
+    turtle.begin_fill();
+    turtle.arc(_radius_inner, None, None);
+    turtle.end_fill();
+
+    let _size = 25.0;
+    turtle.pen_up();
+    turtle.go_to((init_pos.x - (_radius_mid) + _size - 2.0, init_pos.y));
+    turtle.pen_down();
+    turtle.set_pen_size(_size);
+    turtle.forward(250.0);
+}

--- a/examples/dragon_circle.rs
+++ b/examples/dragon_circle.rs
@@ -1,0 +1,29 @@
+extern crate turtle;
+use turtle::Turtle;
+
+enum Turn {
+    Left,
+    Right,
+}
+
+// Shameless copy from https://gist.github.com/fogleman/006e4069348fa163b8ae
+
+fn turn(i: i64) -> Turn {
+    let left = (((i & -i) << 1) & i) != 0;
+    if left {
+        return Turn::Left;
+    } else {
+        return Turn::Right;
+    }
+}
+
+fn main() {
+    let mut turtle = Turtle::new();
+    turtle.set_speed("instant");
+    for i in 1..100000 {
+        match turn(i) {
+            Turn::Left => turtle.arc(-4.0, Some(90.0), Some(36)),
+            Turn::Right => turtle.arc(4.0, Some(90.0), Some(36)),
+        }
+    }
+}

--- a/src/turtle.rs
+++ b/src/turtle.rs
@@ -1,8 +1,8 @@
 use std::fmt::Debug;
 
-use crate::{Color, Point, Speed, Distance, Angle};
 use crate::async_turtle::AsyncTurtle;
 use crate::sync_runtime::block_on;
+use crate::{Angle, Color, Distance, Point, Speed};
 
 /// A turtle with a pen attached to its tail
 ///
@@ -26,7 +26,7 @@ impl Default for Turtle {
 
 impl From<AsyncTurtle> for Turtle {
     fn from(turtle: AsyncTurtle) -> Self {
-        Self {turtle}
+        Self { turtle }
     }
 }
 
@@ -197,6 +197,46 @@ impl Turtle {
     /// ```
     pub fn wait(&mut self, secs: f64) {
         block_on(self.turtle.wait(secs))
+    }
+
+    /// Instructs the turtle to draw an arc by the given angle for a given radius in the given step count from the current position of the turtle.
+    ///
+    /// The `radius` parameter is a floation point number that represents the radius of the arc
+    /// that you want to draw. If a negative `radius` is passed its absolute value is
+    /// considered for drawing the arc.
+    ///
+    /// The `extent` parameter is a floating point number that represents how much you want the
+    /// turtle to rotate. If the `extent` parameter is `None` then it is defaulted to 360. If
+    /// a negative `extent` is passed the arc is drawn in the opposite direction.
+    ///
+    /// the `steps` parameter is an integer that represent over how many steps you want the turtle to draw. If the `steps` parameter
+    /// is `None` then it is defaulted to the arc_length / 4.0.
+    ///
+    /// #Example
+    ///
+    /// ```rust
+    /// # use turtle::*;
+    /// # let mut turtle = Turtle::new();
+    /// // Turtle will draw an arc of 90 in a clockwise direction
+    /// turtle.arc(100.0, Some(90.0), None);
+    ///
+    /// // Turtle will draw an arc of 90 in a anti-clockwise direction
+    /// turtle.arc(-100.0, Some(90.0), None);
+    ///
+    /// // Turtle will draw an arc of 90 in a clockwise direction
+    /// turtle.arc(-100.0, Some(-90.0), None);
+    ///
+    /// //Turtle will draw an arc of 90 in a anti-clockwise direction
+    /// turtle.arc(-100.0, Some(90.0), None);
+    ///
+    /// // Turtle will draw an arc of 90 in a clockwise direction in 10 steps
+    /// turtle.arc(100.0, Some(90.0), Some(10));
+    ///
+    /// // Turtle will draw an arc of 90 in a clockwise direction in 100 steps
+    /// turtle.arc(100.0, Some(90.0), Some(100));
+    /// ```
+    pub fn arc(&mut self, radius: Distance, extent: Option<Angle>, steps: Option<i32>) {
+        block_on(self.turtle.arc(radius, extent, steps))
     }
 
     pub(crate) fn into_async(self) -> AsyncTurtle {
@@ -964,7 +1004,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Invalid color: Color { red: NaN, green: 0.0, blue: 0.0, alpha: 0.0 }. See the color module documentation for more information.")]
+    #[should_panic(
+        expected = "Invalid color: Color { red: NaN, green: 0.0, blue: 0.0, alpha: 0.0 }. See the color module documentation for more information."
+    )]
     fn rejects_invalid_pen_color() {
         let mut turtle = Turtle::new();
         turtle.set_pen_color(Color {
@@ -976,7 +1018,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Invalid color: Color { red: NaN, green: 0.0, blue: 0.0, alpha: 0.0 }. See the color module documentation for more information.")]
+    #[should_panic(
+        expected = "Invalid color: Color { red: NaN, green: 0.0, blue: 0.0, alpha: 0.0 }. See the color module documentation for more information."
+    )]
     fn rejects_invalid_fill_color() {
         let mut turtle = Turtle::new();
         turtle.set_fill_color(Color {


### PR DESCRIPTION
Fixes #82 

Expanded on @DeltaManiac's work in #100 now that #173 was merged. Added a step parameter to more closely resemble the Python implementation's circle method.

Also added a second dragon curve example using the arc method compared to without it.