### PR TITLE
Docs images helper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ once_cell = "1.3"
 
 cfg-if = "0.1"
 
+turtle_docs_helper = { path = "turtle_docs_helper", optional = true }
+
 [dependencies.futures-util]
 version = "0.3"
 default-features = false
@@ -90,7 +92,8 @@ opt-level = 3
 
 [features]
 # The reason we do this is because doctests don't get cfg(test)
-# See: https://github.com/rust-lang/cargo/issues/4669
+# See: https://github.com/rust-lang/cargo/issues/4669 (original issue)
+# See: https://github.com/rust-lang/rust/issues/45599 (updated issue)
 #
 # This allows us to write attributes like the following and have it work
 # in all tests.
@@ -105,3 +108,4 @@ test = []
 #
 # Users of the crate must explicitly opt-in to activate them.
 unstable = []
+docs_image = ["turtle_docs_helper"]

--- a/src/async_drawing.rs
+++ b/src/async_drawing.rs
@@ -1,11 +1,11 @@
 use std::fmt::Debug;
 use std::path::Path;
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
-use crate::ipc_protocol::ProtocolClient;
 use crate::async_turtle::AsyncTurtle;
-use crate::{Drawing, Point, Color, Event, ExportError};
+use crate::ipc_protocol::ProtocolClient;
+use crate::{Color, Drawing, Event, ExportError, Point};
 
 /// Represents a size
 ///
@@ -64,6 +64,16 @@ impl From<Drawing> for AsyncDrawing {
     }
 }
 
+use crate::sync_runtime::block_on;
+#[cfg(feature = "docs_image")]
+use turtle_docs_helper;
+#[cfg(feature = "docs_image")]
+impl turtle_docs_helper::SaveSvg for AsyncDrawing {
+    fn save_svg(&self, path: &Path) -> Result<(), String> {
+        self.client.save_svg(path)
+    }
+}
+
 impl AsyncDrawing {
     pub async fn new() -> Self {
         // This needs to be called as close to the start of the program as possible. We call it
@@ -71,9 +81,8 @@ impl AsyncDrawing {
         // of many programs that use the turtle crate.
         crate::start();
 
-        let client = ProtocolClient::new().await
-            .expect("unable to create renderer client");
-        Self {client}
+        let client = ProtocolClient::new().await.expect("unable to create renderer client");
+        Self { client }
     }
 
     pub async fn add_turtle(&mut self) -> AsyncTurtle {

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -67,6 +67,13 @@ impl From<AsyncDrawing> for Drawing {
     }
 }
 
+#[cfg(docs_images)]
+impl turtle_docs_helpers::SaveSvg for Drawing {
+    fn save_svg(&self, path: &Path) {
+        self.drawing.save_svg(path).unwrap();
+    }
+}
+
 impl Drawing {
     /// Creates a new drawing
     ///
@@ -142,7 +149,7 @@ impl Drawing {
     ///
     /// # Example
     ///
-    /// ```rust,no_run
+    /// ```rust
     /// use turtle::Drawing;
     ///
     /// fn main() {
@@ -150,6 +157,14 @@ impl Drawing {
     ///     # #[allow(unused)] // Good to show turtle creation here even if unused
     ///     let mut turtle = drawing.add_turtle();
     ///     drawing.set_title("My Fancy Title! - Yay!");
+    ///     println!("hello");
+    ///     # #[cfg(docs_image)] 
+    ///     # println!("test");
+    ///     # #[cfg(docs_image)] 
+    ///     # turtle_docs_helpers::foo();
+    ///     # #[cfg(docs_image)] 
+    ///     # turtle_docs_helpers::save_docs_image(&drawing, "cats");
+    ///     
     /// }
     /// ```
     ///

--- a/src/ipc_protocol/protocol.rs
+++ b/src/ipc_protocol/protocol.rs
@@ -1,22 +1,13 @@
 use std::path::PathBuf;
 
-use crate::renderer_client::RendererClient;
-use crate::renderer_server::{TurtleId, ExportError};
 use crate::radians::Radians;
-use crate::{Distance, Point, Color, Speed, Event, Size};
+use crate::renderer_client::RendererClient;
+use crate::renderer_server::{ExportError, TurtleId};
+use crate::{Color, Distance, Event, Point, Size, Speed};
 
 use super::{
-    ConnectionError,
-    ClientRequest,
-    ServerResponse,
-    ExportFormat,
-    DrawingProp,
-    DrawingPropValue,
-    TurtleProp,
-    TurtlePropValue,
-    PenProp,
-    PenPropValue,
-    RotationDirection,
+    ClientRequest, ConnectionError, DrawingProp, DrawingPropValue, ExportFormat, PenProp, PenPropValue, RotationDirection, ServerResponse,
+    TurtleProp, TurtlePropValue,
 };
 
 /// A wrapper for `RendererClient` that encodes the the IPC protocol in a type-safe manner
@@ -26,7 +17,26 @@ pub struct ProtocolClient {
 
 impl From<RendererClient> for ProtocolClient {
     fn from(client: RendererClient) -> Self {
-        Self {client}
+        Self { client }
+    }
+}
+
+#[cfg(feature = "docs_image")]
+use turtle_docs_helper;
+
+#[cfg(feature = "docs_image")]
+use std::path::Path;
+
+#[cfg(feature = "docs_image")]
+use crate::sync_runtime::block_on;
+
+#[cfg(feature = "docs_image")]
+impl turtle_docs_helper::SaveSvg for ProtocolClient {
+    fn save_svg(&self, path: &Path) -> Result<(), String> {
+        match block_on(self.export_svg(path.to_path_buf())) {
+            Ok(()) => Ok(()),
+            Err(e) => Err(e.to_string()),
+        }
     }
 }
 
@@ -137,26 +147,37 @@ impl ProtocolClient {
     }
 
     pub fn drawing_set_background(&self, value: Color) {
-        debug_assert!(value.is_valid(), "bug: colors should be validated before sending to renderer server");
+        debug_assert!(
+            value.is_valid(),
+            "bug: colors should be validated before sending to renderer server"
+        );
         self.client.send(ClientRequest::SetDrawingProp(DrawingPropValue::Background(value)))
     }
 
     pub fn drawing_set_center(&self, value: Point) {
-        debug_assert!(value.is_finite(), "bug: center should be validated before sending to renderer server");
+        debug_assert!(
+            value.is_finite(),
+            "bug: center should be validated before sending to renderer server"
+        );
         self.client.send(ClientRequest::SetDrawingProp(DrawingPropValue::Center(value)))
     }
 
     pub fn drawing_set_size(&self, value: Size) {
-        debug_assert!(value.width > 0 && value.height > 0, "bug: size should be validated before sending to renderer server");
+        debug_assert!(
+            value.width > 0 && value.height > 0,
+            "bug: size should be validated before sending to renderer server"
+        );
         self.client.send(ClientRequest::SetDrawingProp(DrawingPropValue::Size(value)))
     }
 
     pub fn drawing_set_is_maximized(&self, value: bool) {
-        self.client.send(ClientRequest::SetDrawingProp(DrawingPropValue::IsMaximized(value)))
+        self.client
+            .send(ClientRequest::SetDrawingProp(DrawingPropValue::IsMaximized(value)))
     }
 
     pub fn drawing_set_is_fullscreen(&self, value: bool) {
-        self.client.send(ClientRequest::SetDrawingProp(DrawingPropValue::IsFullscreen(value)))
+        self.client
+            .send(ClientRequest::SetDrawingProp(DrawingPropValue::IsFullscreen(value)))
     }
 
     pub fn drawing_reset_center(&self) {
@@ -175,7 +196,7 @@ impl ProtocolClient {
             ServerResponse::TurtleProp(recv_id, TurtlePropValue::Pen(PenPropValue::IsEnabled(value))) => {
                 debug_assert_eq!(id, recv_id, "bug: received data for incorrect turtle");
                 value
-            },
+            }
             _ => unreachable!("bug: expected to receive `TurtleProp` in response to `TurtleProp` request"),
         }
     }
@@ -188,7 +209,7 @@ impl ProtocolClient {
             ServerResponse::TurtleProp(recv_id, TurtlePropValue::Pen(PenPropValue::Thickness(value))) => {
                 debug_assert_eq!(id, recv_id, "bug: received data for incorrect turtle");
                 value
-            },
+            }
             _ => unreachable!("bug: expected to receive `TurtleProp` in response to `TurtleProp` request"),
         }
     }
@@ -201,7 +222,7 @@ impl ProtocolClient {
             ServerResponse::TurtleProp(recv_id, TurtlePropValue::Pen(PenPropValue::Color(value))) => {
                 debug_assert_eq!(id, recv_id, "bug: received data for incorrect turtle");
                 value
-            },
+            }
             _ => unreachable!("bug: expected to receive `TurtleProp` in response to `TurtleProp` request"),
         }
     }
@@ -214,7 +235,7 @@ impl ProtocolClient {
             ServerResponse::TurtleProp(recv_id, TurtlePropValue::FillColor(value)) => {
                 debug_assert_eq!(id, recv_id, "bug: received data for incorrect turtle");
                 value
-            },
+            }
             _ => unreachable!("bug: expected to receive `TurtleProp` in response to `TurtleProp` request"),
         }
     }
@@ -227,7 +248,7 @@ impl ProtocolClient {
             ServerResponse::TurtleProp(recv_id, TurtlePropValue::IsFilling(value)) => {
                 debug_assert_eq!(id, recv_id, "bug: received data for incorrect turtle");
                 value
-            },
+            }
             _ => unreachable!("bug: expected to receive `TurtleProp` in response to `TurtleProp` request"),
         }
     }
@@ -240,7 +261,7 @@ impl ProtocolClient {
             ServerResponse::TurtleProp(recv_id, TurtlePropValue::Position(value)) => {
                 debug_assert_eq!(id, recv_id, "bug: received data for incorrect turtle");
                 value
-            },
+            }
             _ => unreachable!("bug: expected to receive `TurtleProp` in response to `TurtleProp` request"),
         }
     }
@@ -253,7 +274,7 @@ impl ProtocolClient {
             ServerResponse::TurtleProp(recv_id, TurtlePropValue::Heading(value)) => {
                 debug_assert_eq!(id, recv_id, "bug: received data for incorrect turtle");
                 value
-            },
+            }
             _ => unreachable!("bug: expected to receive `TurtleProp` in response to `TurtleProp` request"),
         }
     }
@@ -266,7 +287,7 @@ impl ProtocolClient {
             ServerResponse::TurtleProp(recv_id, TurtlePropValue::Speed(value)) => {
                 debug_assert_eq!(id, recv_id, "bug: received data for incorrect turtle");
                 value
-            },
+            }
             _ => unreachable!("bug: expected to receive `TurtleProp` in response to `TurtleProp` request"),
         }
     }
@@ -279,28 +300,45 @@ impl ProtocolClient {
             ServerResponse::TurtleProp(recv_id, TurtlePropValue::IsVisible(value)) => {
                 debug_assert_eq!(id, recv_id, "bug: received data for incorrect turtle");
                 value
-            },
+            }
             _ => unreachable!("bug: expected to receive `TurtleProp` in response to `TurtleProp` request"),
         }
     }
 
     pub fn turtle_pen_set_is_enabled(&self, id: TurtleId, value: bool) {
-        self.client.send(ClientRequest::SetTurtleProp(id, TurtlePropValue::Pen(PenPropValue::IsEnabled(value))))
+        self.client.send(ClientRequest::SetTurtleProp(
+            id,
+            TurtlePropValue::Pen(PenPropValue::IsEnabled(value)),
+        ))
     }
 
     pub fn turtle_pen_set_thickness(&self, id: TurtleId, value: f64) {
-        debug_assert!(value >= 0.0 && value.is_finite(), "bug: pen size should be validated before sending to renderer server");
-        self.client.send(ClientRequest::SetTurtleProp(id, TurtlePropValue::Pen(PenPropValue::Thickness(value))))
+        debug_assert!(
+            value >= 0.0 && value.is_finite(),
+            "bug: pen size should be validated before sending to renderer server"
+        );
+        self.client.send(ClientRequest::SetTurtleProp(
+            id,
+            TurtlePropValue::Pen(PenPropValue::Thickness(value)),
+        ))
     }
 
     pub fn turtle_pen_set_color(&self, id: TurtleId, value: Color) {
-        debug_assert!(value.is_valid(), "bug: colors should be validated before sending to renderer server");
-        self.client.send(ClientRequest::SetTurtleProp(id, TurtlePropValue::Pen(PenPropValue::Color(value))))
+        debug_assert!(
+            value.is_valid(),
+            "bug: colors should be validated before sending to renderer server"
+        );
+        self.client
+            .send(ClientRequest::SetTurtleProp(id, TurtlePropValue::Pen(PenPropValue::Color(value))))
     }
 
     pub fn turtle_set_fill_color(&self, id: TurtleId, value: Color) {
-        debug_assert!(value.is_valid(), "bug: colors should be validated before sending to renderer server");
-        self.client.send(ClientRequest::SetTurtleProp(id, TurtlePropValue::FillColor(value)))
+        debug_assert!(
+            value.is_valid(),
+            "bug: colors should be validated before sending to renderer server"
+        );
+        self.client
+            .send(ClientRequest::SetTurtleProp(id, TurtlePropValue::FillColor(value)))
     }
 
     pub fn turtle_set_speed(&self, id: TurtleId, value: Speed) {
@@ -308,7 +346,8 @@ impl ProtocolClient {
     }
 
     pub fn turtle_set_is_visible(&self, id: TurtleId, value: bool) {
-        self.client.send(ClientRequest::SetTurtleProp(id, TurtlePropValue::IsVisible(value)))
+        self.client
+            .send(ClientRequest::SetTurtleProp(id, TurtlePropValue::IsVisible(value)))
     }
 
     pub fn turtle_reset_heading(&self, id: TurtleId) {
@@ -330,7 +369,7 @@ impl ProtocolClient {
         match response {
             ServerResponse::AnimationComplete(recv_id) => {
                 debug_assert_eq!(id, recv_id, "bug: notified of complete animation for incorrect turtle");
-            },
+            }
             _ => unreachable!("bug: expected to receive `AnimationComplete` in response to `MoveForward` request"),
         }
     }
@@ -346,7 +385,7 @@ impl ProtocolClient {
         match response {
             ServerResponse::AnimationComplete(recv_id) => {
                 debug_assert_eq!(id, recv_id, "bug: notified of complete animation for incorrect turtle");
-            },
+            }
             _ => unreachable!("bug: expected to receive `AnimationComplete` in response to `MoveTo` request"),
         }
     }
@@ -362,7 +401,7 @@ impl ProtocolClient {
         match response {
             ServerResponse::AnimationComplete(recv_id) => {
                 debug_assert_eq!(id, recv_id, "bug: notified of complete animation for incorrect turtle");
-            },
+            }
             _ => unreachable!("bug: expected to receive `AnimationComplete` in response to `RotateInPlace` request"),
         }
     }

--- a/src/turtle.rs
+++ b/src/turtle.rs
@@ -1,8 +1,13 @@
 use std::fmt::Debug;
 
-use crate::{Color, Point, Speed, Distance, Angle};
 use crate::async_turtle::AsyncTurtle;
 use crate::sync_runtime::block_on;
+use crate::{Angle, Color, Distance, Point, Speed};
+
+#[cfg(feature = "docs_image")]
+use std::path::Path;
+#[cfg(feature = "docs_image")]
+use turtle_docs_helper;
 
 /// A turtle with a pen attached to its tail
 ///
@@ -26,7 +31,17 @@ impl Default for Turtle {
 
 impl From<AsyncTurtle> for Turtle {
     fn from(turtle: AsyncTurtle) -> Self {
-        Self {turtle}
+        Self { turtle }
+    }
+}
+
+#[cfg(feature = "docs_image")]
+impl turtle_docs_helper::SaveSvg for Turtle {
+    fn save_svg(&self, path: &Path) -> Result<(), String> {
+        match self.turtle.save_svg(path) {
+            Ok(()) => Ok(()),
+            Err(e) => Err(e.to_string()),
+        }
     }
 }
 
@@ -528,7 +543,7 @@ impl Turtle {
     ///
     /// # Example
     ///
-    /// ```rust,no_run
+    /// ```rust
     /// use turtle::Turtle;
     ///
     /// fn main() {
@@ -550,6 +565,8 @@ impl Turtle {
     ///     turtle.set_pen_color("#4CAF50"); // green
     ///     turtle.set_pen_size(100.0);
     ///     turtle.forward(200.0);
+    ///     # #[cfg(feature = "docs_image")]
+    ///     # turtle_docs_helper::save_docs_image(&turtle, "pen_thickness");
     /// }
     /// ```
     ///
@@ -584,7 +601,7 @@ impl Turtle {
     ///
     /// # Example
     ///
-    /// ```rust,no_run
+    /// ```rust
     /// use turtle::Drawing;
     ///
     /// fn main() {
@@ -600,6 +617,8 @@ impl Turtle {
     ///         turtle.forward(25.0);
     ///         turtle.right(10.0);
     ///     }
+    ///     # #[cfg(feature = "docs_image")]
+    ///     # turtle_docs_helper::save_docs_image(&drawing, "colored_circle");
     /// }
     /// ```
     ///
@@ -700,6 +719,8 @@ impl Turtle {
     ///     }
     ///     turtle.right(90.0);
     ///     turtle.forward(120.0);
+    ///     # #[cfg(feature = "docs_image")]
+    ///     # turtle_docs_helper::save_docs_image(&turtle, "red_circle");
     /// }
     /// ```
     ///
@@ -795,16 +816,32 @@ impl Turtle {
     ///
     /// # Example
     ///
-    /// ```rust,no_run
+    /// ```rust
     /// use turtle::Turtle;
     ///
     /// fn main() {
     ///     let mut turtle = Turtle::new();
     ///     turtle.right(32.0);
     ///     turtle.forward(150.0);
-    ///
+    ///     # #[cfg(feature = "docs_image")]
+    ///     # turtle_docs_helper::save_docs_image(&turtle, "clear_before_click");
+    /// # }
+    /// ```
+    /// ```rust, no_run
+    /// # use turtle::Turtle;
+    ///     # let mut turtle = Turtle::new();
     ///     turtle.wait_for_click();
+    /// ```
+    /// ```rust
+    /// # use turtle::Turtle;
+    ///
+    /// # fn main() {
+    ///    # let mut turtle = Turtle::new();
+    ///    # turtle.right(32.0);
+    ///    # turtle.forward(150.0);
     ///     turtle.clear();
+    /// # #[cfg(feature = "docs_image")]
+    ///     # turtle_docs_helper::save_docs_image(&turtle, "clear_after_click");
     /// }
     /// ```
     ///
@@ -964,7 +1001,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Invalid color: Color { red: NaN, green: 0.0, blue: 0.0, alpha: 0.0 }. See the color module documentation for more information.")]
+    #[should_panic(
+        expected = "Invalid color: Color { red: NaN, green: 0.0, blue: 0.0, alpha: 0.0 }. See the color module documentation for more information."
+    )]
     fn rejects_invalid_pen_color() {
         let mut turtle = Turtle::new();
         turtle.set_pen_color(Color {
@@ -976,7 +1015,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Invalid color: Color { red: NaN, green: 0.0, blue: 0.0, alpha: 0.0 }. See the color module documentation for more information.")]
+    #[should_panic(
+        expected = "Invalid color: Color { red: NaN, green: 0.0, blue: 0.0, alpha: 0.0 }. See the color module documentation for more information."
+    )]
     fn rejects_invalid_fill_color() {
         let mut turtle = Turtle::new();
         turtle.set_fill_color(Color {

--- a/turtle_docs_helper/Cargo.toml
+++ b/turtle_docs_helper/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "turtle_docs_helper"
+version = "0.1.0"
+authors = ["Joe Ling"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/turtle_docs_helper/src/lib.rs
+++ b/turtle_docs_helper/src/lib.rs
@@ -1,0 +1,22 @@
+use std::path::Path; 
+ 
+
+
+ /// Saves the image being drawn as an SVG and panics if an error occurs
+ ///
+ /// This is different from the `save_svg` method on `Drawing` and `AsyncDrawing`
+ /// because this is only meant to be used for automation and may need to access
+ /// internal APIs.
+ pub trait SaveSvg {
+    fn save_svg(&self, path: &Path);
+}
+
+
+
+/// Saves the currently drawn image to `docs/assets/images/docs/{output_name}`
+pub fn save_docs_image<T: SaveSvg>(drawing: &T, output_name: &str) {
+    println!("saving image");
+    let svg_path = &Path::new("docs/assets/images/docs").join(output_name).with_extension("svg");
+    drawing.save_svg(svg_path);
+    assert_eq!(1,2);
+}

--- a/turtle_docs_helper/src/lib.rs
+++ b/turtle_docs_helper/src/lib.rs
@@ -1,22 +1,15 @@
 use std::path::Path; 
- 
-
-
  /// Saves the image being drawn as an SVG and panics if an error occurs
  ///
  /// This is different from the `save_svg` method on `Drawing` and `AsyncDrawing`
  /// because this is only meant to be used for automation and may need to access
  /// internal APIs.
  pub trait SaveSvg {
-    fn save_svg(&self, path: &Path);
+    fn save_svg(&self, path: &Path) -> Result<(), String>;
 }
-
-
 
 /// Saves the currently drawn image to `docs/assets/images/docs/{output_name}`
 pub fn save_docs_image<T: SaveSvg>(drawing: &T, output_name: &str) {
-    println!("saving image");
     let svg_path = &Path::new("docs/assets/images/docs").join(output_name).with_extension("svg");
-    drawing.save_svg(svg_path);
-    assert_eq!(1,2);
+    assert!(drawing.save_svg(svg_path).is_ok());
 }


### PR DESCRIPTION
For https://github.com/sunjay/turtle/issues/179 this implements generating the svgs from the doc tests using `docs_image` feature flag. 

There was one main slight complication in that a few examples required the user to click on the window. For those tests which where originally `no_run` I split them up into separate doc tests but hopefully they should all be one coherent code example... 

- [ ] check if this is correct approach
- [ ] convert the svg to png and then clean up the svg (as svgs aren't normally supported in md)
- [ ] improve svg rendering as the turtle currently isn't shown in the render which is needed for one or two examples as well as the title. This could be handled with if the turtle `is_visible`, for the title bar I am not sure the best way to handle it but it is easy to get the data out. 
