### PR TITLE
Implementing Debug for Turtle and Drawing

### DIFF
--- a/src/async_drawing.rs
+++ b/src/async_drawing.rs
@@ -175,9 +175,9 @@ impl AsyncDrawing {
     // think things through before making this method public.
     /// # Stability
     ///
-    /// **Warning:** This method exists because it is necessary to do some work
-    /// currently asynchronously in order to print out a useful debug
-    /// representation of this type. There is no async `Debug` trait. Please
+    /// **Warning:** This method exists because it is currently necessary to
+    /// do some work asynchronously in order to print out a useful debug
+    /// representation for this type. There is no async `Debug` trait. Please
     /// only use this method for debugging. It may be removed in a future
     /// release if we find a way to implement `Debug` trait for this type.
     pub async fn debug(&self) -> impl Debug {

--- a/src/async_drawing.rs
+++ b/src/async_drawing.rs
@@ -6,6 +6,7 @@ use serde::{Serialize, Deserialize};
 use crate::ipc_protocol::ProtocolClient;
 use crate::async_turtle::AsyncTurtle;
 use crate::{Drawing, Point, Color, Event, ExportError};
+use crate::debug;
 
 /// Represents a size
 ///
@@ -168,5 +169,12 @@ impl AsyncDrawing {
 
     pub async fn save_svg<P: AsRef<Path>>(&self, path: P) -> Result<(), ExportError> {
         self.client.export_svg(path.as_ref().to_path_buf()).await
+    }
+
+    //TODO: If we move to a shared memory architecture, we wouldn't need to make
+    // any request here and thus would not need this method at all. We should
+    // think things through before making this method public.
+    pub(crate) async fn debug(&self) -> debug::Drawing {
+        self.client.debug_drawing().await
     }
 }

--- a/src/async_drawing.rs
+++ b/src/async_drawing.rs
@@ -6,7 +6,6 @@ use serde::{Serialize, Deserialize};
 use crate::ipc_protocol::ProtocolClient;
 use crate::async_turtle::AsyncTurtle;
 use crate::{Drawing, Point, Color, Event, ExportError};
-use crate::debug;
 
 /// Represents a size
 ///
@@ -181,7 +180,7 @@ impl AsyncDrawing {
     /// representation of this type. There is no async `Debug` trait. Please
     /// only use this method for debugging. It may be removed in a future
     /// release if we find a way to implement `Debug` trait for this type.
-    pub(crate) async fn debug(&self) -> debug::Drawing {
+    pub async fn debug(&self) -> impl Debug {
         self.client.debug_drawing().await
     }
 }

--- a/src/async_drawing.rs
+++ b/src/async_drawing.rs
@@ -174,6 +174,13 @@ impl AsyncDrawing {
     //TODO: If we move to a shared memory architecture, we wouldn't need to make
     // any request here and thus would not need this method at all. We should
     // think things through before making this method public.
+    /// # Stability
+    ///
+    /// **Warning:** This method exists because it is necessary to do some work
+    /// currently asynchronously in order to print out a useful debug
+    /// representation of this type. There is no async `Debug` trait. Please
+    /// only use this method for debugging. It may be removed in a future
+    /// release if we find a way to implement `Debug` trait for this type.
     pub(crate) async fn debug(&self) -> debug::Drawing {
         self.client.debug_drawing().await
     }

--- a/src/async_turtle.rs
+++ b/src/async_turtle.rs
@@ -6,7 +6,6 @@ use crate::radians::{self, Radians};
 use crate::ipc_protocol::{ProtocolClient, RotationDirection};
 use crate::renderer_server::TurtleId;
 use crate::{Turtle, Color, Point, Speed};
-use crate::debug;
 
 /// Any distance value (positive or negative)
 pub type Distance = f64;
@@ -321,7 +320,7 @@ impl AsyncTurtle {
     /// representation of this type. There is no async `Debug` trait. Please
     /// only use this method for debugging. It may be removed in a future
     /// release if we find a way to implement `Debug` trait for this type.
-    pub(crate) async fn debug(&self) -> debug::Turtle {
+    pub async fn debug(&self) -> impl Debug {
         self.client.debug_turtle(self.id, self.angle_unit).await
     }
 }

--- a/src/async_turtle.rs
+++ b/src/async_turtle.rs
@@ -314,6 +314,13 @@ impl AsyncTurtle {
     //TODO: If we move to a shared memory architecture, we wouldn't need to make
     // any request here and thus would not need this method at all. We should
     // think things through before making this method public.
+    /// # Stability
+    ///
+    /// **Warning:** This method exists because it is necessary to do some work
+    /// currently asynchronously in order to print out a useful debug
+    /// representation of this type. There is no async `Debug` trait. Please
+    /// only use this method for debugging. It may be removed in a future
+    /// release if we find a way to implement `Debug` trait for this type.
     pub(crate) async fn debug(&self) -> debug::Turtle {
         self.client.debug_turtle(self.id, self.angle_unit).await
     }

--- a/src/async_turtle.rs
+++ b/src/async_turtle.rs
@@ -6,6 +6,7 @@ use crate::radians::{self, Radians};
 use crate::ipc_protocol::{ProtocolClient, RotationDirection};
 use crate::renderer_server::TurtleId;
 use crate::{Turtle, Color, Point, Speed};
+use crate::debug;
 
 /// Any distance value (positive or negative)
 pub type Distance = f64;
@@ -17,8 +18,8 @@ pub type Distance = f64;
 /// [`use_radians()`](struct.Turtle.html#method.use_radians) methods for more information.
 pub type Angle = f64;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum AngleUnit {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum AngleUnit {
     Degrees,
     Radians,
 }
@@ -308,5 +309,12 @@ impl AsyncTurtle {
             // Sleep for ~1 frame (at 120fps) to avoid pegging the CPU.
             self.wait(1.0 / 120.0).await;
         }
+    }
+
+    //TODO: If we move to a shared memory architecture, we wouldn't need to make
+    // any request here and thus would not need this method at all. We should
+    // think things through before making this method public.
+    pub(crate) async fn debug(&self) -> debug::Turtle {
+        self.client.debug_turtle(self.id, self.angle_unit).await
     }
 }

--- a/src/async_turtle.rs
+++ b/src/async_turtle.rs
@@ -315,9 +315,9 @@ impl AsyncTurtle {
     // think things through before making this method public.
     /// # Stability
     ///
-    /// **Warning:** This method exists because it is necessary to do some work
-    /// currently asynchronously in order to print out a useful debug
-    /// representation of this type. There is no async `Debug` trait. Please
+    /// **Warning:** This method exists because it is currently necessary to
+    /// do some work asynchronously in order to print out a useful debug
+    /// representation for this type. There is no async `Debug` trait. Please
     /// only use this method for debugging. It may be removed in a future
     /// release if we find a way to implement `Debug` trait for this type.
     pub async fn debug(&self) -> impl Debug {

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,0 +1,64 @@
+//! Debug representations of the turtle and drawing state
+//!
+//! These are not required to exactly match our internal representation of the
+//! state. Instead, we should focus on making a printable representation that is
+//! as useful for debugging as possible.
+//!
+//! To avoid confusion, these types are not usually imported by name. Instead,
+//! it's best to import the `turtle::debug` module and use the types through
+//! that. Example: `debug::Turtle`, `debug::Drawing`, etc.
+
+use std::fmt;
+
+use serde::{Serialize, Deserialize};
+
+use crate::{Color, Point, Speed};
+
+// None of the struct fields are public because we don't want to expose any
+// internal details. These types are for printing only!
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Drawing {
+    pub(crate) title: String,
+    pub(crate) background: Color,
+    pub(crate) center: Point,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    pub(crate) is_maximized: bool,
+    pub(crate) is_fullscreen: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Turtle {
+    pub(crate) position: Point,
+    pub(crate) heading: DebugAngle,
+    pub(crate) speed: Speed,
+    pub(crate) pen: Pen,
+    pub(crate) fill_color: Color,
+    pub(crate) is_visible: bool,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) enum DebugAngle {
+    /// An angle in degrees
+    Degrees(f64),
+    /// An angle in radians
+    Radians(f64),
+}
+
+impl fmt::Debug for DebugAngle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use DebugAngle::*;
+        match self {
+            Degrees(value) => write!(f, "{}\u{00B0}", value),
+            Radians(value) => write!(f, "{} rad", value),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Pen {
+    pub(crate) is_enabled: bool,
+    pub(crate) thickness: f64,
+    pub(crate) color: Color,
+}

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 use std::path::Path;
 
 use crate::{Turtle, Color, Point, Size, ExportError};
@@ -57,6 +57,13 @@ pub struct Drawing {
     drawing: AsyncDrawing,
     //TODO: Remove this field when multiple turtles are supported
     turtles: usize,
+}
+
+impl Debug for Drawing {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let state = block_on(self.drawing.debug());
+        Debug::fmt(&state, f)
+    }
 }
 
 impl From<AsyncDrawing> for Drawing {

--- a/src/ipc_protocol/messages.rs
+++ b/src/ipc_protocol/messages.rs
@@ -4,7 +4,7 @@ use serde::{Serialize, Deserialize};
 
 use crate::{Color, Point, Speed, Event, Distance, Size};
 use crate::renderer_server::{TurtleId, ExportError};
-use crate::radians::Radians;
+use crate::{async_turtle::AngleUnit, radians::Radians, debug};
 
 /// The different kinds of requests that can be sent from a client
 ///
@@ -141,6 +141,17 @@ pub enum ClientRequest {
     ///
     /// Response: N/A
     ClearTurtle(TurtleId),
+
+    /// Returns the entire current state of the given turtle in a format useful
+    /// for printing only.
+    ///
+    /// Response: `ServerResponse::DebugTurtle`
+    DebugTurtle(TurtleId, AngleUnit),
+    /// Returns the entire current state of the drawing in a format useful
+    /// for printing only.
+    ///
+    /// Response: `ServerResponse::DebugDrawing`
+    DebugDrawing,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -165,6 +176,13 @@ pub enum ServerResponse {
 
     /// An animation was completed for a given turtle
     AnimationComplete(TurtleId),
+
+    /// A representation of the entire state of a turtle, suitable for printing
+    /// only
+    DebugTurtle(TurtleId, debug::Turtle),
+    /// A representation of the entire state of the drawing, suitable for
+    /// printing only
+    DebugDrawing(debug::Drawing),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@ mod renderer_client;
 mod async_drawing;
 mod async_turtle;
 mod sync_runtime;
+mod debug;
 mod drawing;
 mod turtle;
 

--- a/src/renderer_server.rs
+++ b/src/renderer_server.rs
@@ -164,6 +164,13 @@ async fn run_request(
         ClearTurtle(id) => {
             handlers::clear_turtle(data_req_queued, &app_control, &display_list, event_loop, id).await
         },
+
+        DebugTurtle(id, angle_unit) => {
+            handlers::debug_turtle(data_req_queued, conn, &app_control, id, angle_unit).await
+        },
+        DebugDrawing => {
+            handlers::debug_drawing(data_req_queued, conn, &app_control).await
+        },
     };
 
     use handlers::HandlerError::*;

--- a/src/renderer_server/handlers.rs
+++ b/src/renderer_server/handlers.rs
@@ -6,6 +6,7 @@ mod turtle_prop;
 mod animation;
 mod fill;
 mod clear;
+mod debug;
 
 pub(crate) use create_turtle::*;
 pub(crate) use export_drawings::*;
@@ -15,6 +16,7 @@ pub(crate) use turtle_prop::*;
 pub(crate) use animation::*;
 pub(crate) use fill::*;
 pub(crate) use clear::*;
+pub(crate) use debug::*;
 
 use thiserror::Error;
 

--- a/src/renderer_server/handlers/debug.rs
+++ b/src/renderer_server/handlers/debug.rs
@@ -1,0 +1,55 @@
+use tokio::sync::oneshot;
+
+use crate::{
+    async_turtle::AngleUnit,
+    ipc_protocol::{
+        ServerOneshotSender,
+        ServerResponse,
+    },
+};
+
+use super::HandlerError;
+use super::super::{
+    app::{TurtleId, TurtleDrawings},
+    access_control::{AccessControl, RequiredData, RequiredTurtles},
+};
+
+pub(crate) async fn debug_turtle(
+    data_req_queued: oneshot::Sender<()>,
+    conn: ServerOneshotSender,
+    app_control: &AccessControl,
+    id: TurtleId,
+    angle_unit: AngleUnit,
+) -> Result<(), HandlerError> {
+    let mut data = app_control.get(RequiredData {
+        drawing: false,
+        turtles: Some(RequiredTurtles::One(id)),
+    }, data_req_queued).await;
+    let mut turtles = data.turtles_mut().await;
+
+    let TurtleDrawings {state: turtle, ..} = turtles.one_mut();
+
+    let debug_state = turtle.to_debug(angle_unit);
+
+    conn.send(ServerResponse::DebugTurtle(id, debug_state))?;
+
+    Ok(())
+}
+
+pub(crate) async fn debug_drawing(
+    data_req_queued: oneshot::Sender<()>,
+    conn: ServerOneshotSender,
+    app_control: &AccessControl,
+) -> Result<(), HandlerError> {
+    let mut data = app_control.get(RequiredData {
+        drawing: true,
+        turtles: None,
+    }, data_req_queued).await;
+    let drawing = data.drawing_mut();
+
+    let debug_state = drawing.to_debug();
+
+    conn.send(ServerResponse::DebugDrawing(debug_state))?;
+
+    Ok(())
+}

--- a/src/renderer_server/state.rs
+++ b/src/renderer_server/state.rs
@@ -2,8 +2,15 @@ use std::f64::consts::PI;
 
 use serde::{Serialize, Deserialize};
 
-use crate::radians::Radians;
-use crate::{Color, Point, Speed, colors::{WHITE, BLACK}};
+use crate::{
+    Color,
+    Point,
+    Speed,
+    debug,
+    radians::Radians,
+    colors::{WHITE, BLACK},
+    async_turtle::AngleUnit,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DrawingState {
@@ -40,6 +47,32 @@ impl Default for DrawingState {
     }
 }
 
+impl DrawingState {
+    pub(crate) fn to_debug(&self) -> debug::Drawing {
+        let &Self {
+            ref title,
+            background,
+            center,
+            width,
+            height,
+            is_maximized,
+            is_fullscreen,
+        } = self;
+
+        let title = title.clone();
+
+        debug::Drawing {
+            title,
+            background,
+            center,
+            width,
+            height,
+            is_maximized,
+            is_fullscreen,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TurtleState {
     pub pen: Pen,
@@ -70,6 +103,34 @@ impl Default for TurtleState {
     }
 }
 
+impl TurtleState {
+    pub(crate) fn to_debug(&self, angle_unit: AngleUnit) -> debug::Turtle {
+        let &Self {
+            position,
+            heading,
+            speed,
+            ref pen,
+            fill_color,
+            is_visible,
+        } = self;
+
+        let heading = match angle_unit {
+            AngleUnit::Degrees => debug::DebugAngle::Degrees(heading.to_degrees()),
+            AngleUnit::Radians => debug::DebugAngle::Radians(heading.to_radians()),
+        };
+        let pen = pen.to_debug();
+
+        debug::Turtle {
+            position,
+            heading,
+            speed,
+            pen,
+            fill_color,
+            is_visible,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Pen {
     pub is_enabled: bool,
@@ -89,6 +150,22 @@ impl Default for Pen {
             is_enabled: Self::DEFAULT_IS_ENABLED,
             thickness: Self::DEFAULT_THICKNESS,
             color: Self::DEFAULT_COLOR,
+        }
+    }
+}
+
+impl Pen {
+    pub(crate) fn to_debug(&self) -> debug::Pen {
+        let &Self {
+            is_enabled,
+            thickness,
+            color,
+        } = self;
+
+        debug::Pen {
+            is_enabled,
+            thickness,
+            color,
         }
     }
 }

--- a/src/speed.rs
+++ b/src/speed.rs
@@ -11,7 +11,7 @@ use crate::Distance;
 const MIN_SPEED: i32 = 1;
 const MAX_SPEED: i32 = 25;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Ord, Hash, Serialize, Deserialize)]
 pub(crate) enum SpeedLevel {
     Value(i32),
     Instant,
@@ -168,7 +168,7 @@ impl PartialOrd for SpeedLevel {
 /// [`set_speed` method]: struct.Turtle.html#method.set_speed
 /// [`Speed::instant()`]: struct.Speed.html#method.instant
 /// [`is_instant()` method]: struct.Speed.html#method.is_instant
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Speed(SpeedLevel);
 
 /// The default speed is "normal"
@@ -279,9 +279,15 @@ impl fmt::Display for Speed {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use SpeedLevel::*;
         match self.0 {
-            Value(speed) => write!(f, "Speed::from({})", speed),
-            Instant => write!(f, "Speed::instant()"),
+            Value(value) => fmt::Display::fmt(&value, f),
+            Instant => write!(f, "\"instant\""),
         }
+    }
+}
+
+impl fmt::Debug for Speed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Speed({})", self)
     }
 }
 

--- a/src/speed.rs
+++ b/src/speed.rs
@@ -381,10 +381,10 @@ mod tests {
     #[test]
     fn display() {
         let speed: Speed = "instant".into();
-        assert_eq!(format!("{}", speed), "Speed::instant()");
+        assert_eq!(format!("{}", speed), "\"instant\"");
         for value in 1..MAX_SPEED {
             let speed: Speed = value.into();
-            assert_eq!(format!("{}", speed), format!("Speed::from({})", value));
+            assert_eq!(format!("{}", speed), format!("{}", value));
         }
     }
 

--- a/src/turtle.rs
+++ b/src/turtle.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 
 use crate::{Color, Point, Speed, Distance, Angle};
 use crate::async_turtle::AsyncTurtle;
@@ -16,6 +16,13 @@ use crate::sync_runtime::block_on;
 /// can use with the turtle.
 pub struct Turtle {
     turtle: AsyncTurtle,
+}
+
+impl Debug for Turtle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let state = block_on(self.turtle.debug());
+        Debug::fmt(&state, f)
+    }
 }
 
 impl Default for Turtle {


### PR DESCRIPTION
Fixes #146 

This PR adds a `Debug` implementation for `Turtle` and `Drawing`. That means that you can print out each of them and get meaningful output.

For example, consider the following code:

```rust
fn main() {
    let mut drawing = Drawing::new();
    let mut turtle = drawing.add_turtle();

    println!("{:#?}", drawing);
    println!("{:#?}", turtle);
}
```

This produces the following output:

```rust
Drawing {
    title: "Turtle",
    background: Color {
        red: 255.0,
        green: 255.0,
        blue: 255.0,
        alpha: 1.0,
    },
    center: Point {
        x: 0.0,
        y: 0.0,
    },
    width: 800,
    height: 600,
    is_maximized: false,
    is_fullscreen: false,
}
Turtle {
    position: Point {
        x: 0.0,
        y: 0.0,
    },
    heading: 90°,
    speed: Speed(10),
    pen: Pen {
        is_enabled: true,
        thickness: 1.0,
        color: Color {
            red: 0.0,
            green: 0.0,
            blue: 0.0,
            alpha: 1.0,
        },
    },
    fill_color: Color {
        red: 0.0,
        green: 0.0,
        blue: 0.0,
        alpha: 1.0,
    },
    is_visible: true,
}
```

Notice that the heading angle is printed in degrees. If the user calls `use_radians`, it will be printed in radians instead. The speed output has also been changed to print a numerical value, e.g. `Speed(20)`, or to print the string `"instant"` when the speed is set to instant, e.g. `Speed("instant")`.

## Implementation

The reason this functionality wasn't added before is because none of this state actually exists in the same process as the `turtle` and `drawing` variables. Printing this information requires making a request to the renderer server. We could potentially cache all of the state and keep it constantly up to date, but that is pretty expensive for a feature that is only meant to be used rarely when you are debugging.

Instead of that, this implementation adds a special `DebugTurtle` and `DebugDrawing` request that fetches a fake, print-only version of the state from the renderer server. In the synchronous `Turtle` and `Drawing` types, this is very convenient because we can implement `Debug` by blocking on that request and printing the output. 

For `AsyncTurtle` and `AsyncDrawing` however, you need to call a special `debug` method and `await` its future in order to do the same. This isn't ideal, but it seems to be a reasonable solution given that there is no async `Debug` trait.

```rust
#[tokio::main]
async fn main() {
    let mut drawing = AsyncDrawing::new();
    let mut turtle = drawing.add_turtle();

    println!("{:#?}", drawing.debug().await);
    println!("{:#?}", turtle.debug().await);
}
```

To avoid leaking the private types that represent the printable state, we use the impl Trait feature in the return type of each `debug` method: `async fn debug(&self) -> impl Debug`. This also helps to make sure these values can only be used for their intended purpose.

## Stability

If one day we end up moving to a shared memory architecture, it may become possible to implement the `Debug` trait for `AsyncTurtle` and `AsyncDrawing` directly. In that case, we may need to deprecate and remove the `debug` methods. I have left a stability note in the documentation for both that indicates that the methods should only be used for debugging and may be removed in the future if we figure out how to implement the `Debug` trait directly.