### PR TITLE
Rewrite and Simplify AccessControl 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ once_cell = "1.3"
 
 cfg-if = "0.1"
 
+parking_lot = "0.10"
+
 [dependencies.futures-util]
 version = "0.3"
 default-features = false

--- a/examples/concurrencytest.rs
+++ b/examples/concurrencytest.rs
@@ -1,0 +1,86 @@
+//! This example uses multiple turtles to demonstrate the sequential consistency guarantees of this
+//! crate.
+//!
+//! Turtle 1: Draws a single long line across the top of the window
+//!
+//! Turtle 2: Draws many short lines across the top of the window
+//!
+//! Turtle 3: Draws a short line, then clears the image (including the lines from Turtle 1 and 2),
+//!   then continues drawing
+//!
+//! If Turtle 1 has already started drawing before Turtle 3 clears the image, Turtle 3 will have to
+//! wait for Turtle 1 to finish drawing its line before it can clear the image and keep drawing.
+//! This is because Turtle 1 has exclusive access to its turtle while it is drawing. The clear
+//! command cannot execute until that line has finished drawing and it is given access.
+//!
+//! Turtle 2 also stops drawing when the drawing is cleared, but for different reasons than
+//! Turtle 3. Turtle 2 can technically still continue because it isn't blocked on a clear command.
+//! The issue is that when clear is run, it reserves all turtles, including Turtle 2. Turtle 2 has
+//! to wait for the clear command to run before it can draw its next line. This is how we ensure
+//! that commands run in the order they are executed (sequential consistency). No command gets
+//! precedence just because the resources it needs are available.
+
+// To run this example, use the command: cargo run --features unstable --example concurrencytest
+#[cfg(all(not(feature = "unstable")))]
+compile_error!("This example relies on unstable features. Run with `--features unstable`");
+
+use std::thread;
+
+use turtle::Drawing;
+
+fn main() {
+    let mut drawing = Drawing::new();
+    let mut turtle1 = drawing.add_turtle();
+    let mut turtle2 = drawing.add_turtle();
+    let mut turtle3 = drawing.add_turtle();
+
+    thread::spawn(move || {
+        turtle1.pen_up();
+        turtle1.set_speed("instant");
+        turtle1.go_to((-350.0, 250.0));
+        turtle1.set_heading(0.0);
+        turtle1.set_speed("normal");
+        turtle1.pen_down();
+
+        turtle1.set_pen_color("green");
+        turtle1.set_pen_size(5.0);
+        turtle1.forward(700.0);
+    });
+
+    thread::spawn(move || {
+        turtle2.pen_up();
+        turtle2.set_speed("instant");
+        turtle2.go_to((-350.0, 200.0));
+        turtle2.set_heading(0.0);
+        turtle2.set_speed("faster");
+        turtle2.pen_down();
+
+        turtle2.set_pen_size(5.0);
+        for i in 0..20 {
+            let color = if i % 2 == 0 {
+                "purple"
+            } else {
+                "pink"
+            };
+            turtle2.set_pen_color(color);
+            turtle2.forward(35.0);
+        }
+    });
+
+    turtle3.pen_up();
+    turtle3.set_speed("instant");
+    turtle3.backward(250.0);
+    turtle3.set_speed("normal");
+    turtle3.pen_down();
+
+    turtle3.set_pen_color("blue");
+    turtle3.set_pen_size(5.0);
+
+    turtle3.forward(100.0);
+    drawing.clear();
+    turtle3.set_pen_color("red");
+    turtle3.forward(100.0);
+
+    //TODO: Currently, if the main thread ends before the other threads, the window just closes
+    thread::park();
+}

--- a/src/async_drawing.rs
+++ b/src/async_drawing.rs
@@ -162,6 +162,10 @@ impl AsyncDrawing {
         self.client.drawing_set_is_fullscreen(false)
     }
 
+    pub fn clear(&mut self) {
+        self.client.clear_all()
+    }
+
     pub async fn poll_event(&mut self) -> Option<Event> {
         self.client.poll_event().await
     }

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -494,6 +494,14 @@ impl Drawing {
         self.drawing.exit_fullscreen()
     }
 
+    //TODO(#16): This method is hidden because it hasn't been properly documented
+    #[doc(hidden)]
+    #[cfg(feature = "unstable")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+    pub fn clear(&mut self) {
+        self.drawing.clear();
+    }
+
     /// Returns the next event (if any). Returns `None` if there are no events to be processed at
     /// the current moment. This **does not** mean that there will never be events later on as the
     /// application continues to run.

--- a/src/ipc_protocol/protocol.rs
+++ b/src/ipc_protocol/protocol.rs
@@ -375,7 +375,6 @@ impl ProtocolClient {
         self.client.send(ClientRequest::EndFill(id))
     }
 
-    #[allow(dead_code)] //TODO(#16): This is part of the multiple turtles feature (for Drawing::clear())
     pub fn clear_all(&self) {
         self.client.send(ClientRequest::ClearAll)
     }

--- a/src/renderer_server/access_control.rs
+++ b/src/renderer_server/access_control.rs
@@ -465,9 +465,11 @@ impl AccessControl {
         }
 
         // Signal that all data requests have been queued and the next call to get() can proceed.
-        // This is very important to get the ordering guarantees we are going for. Without this,
-        // we would have a race condition between all callers of get() where the order would be
-        // randomly determined based on the order the tasks calling get() are scheduled.
+        // This is necessary since we can only guarantee request ordering if each request gets to
+        // this point before the next call to `get`. Without this, we would have a race condition
+        // between all callers of get() where the order would be randomly determined based on the
+        // order that the tasks calling get() are scheduled.
+        //
         // Ignoring errors since this just means that whoever was waiting to find out when the
         // requests have been queued no longer needs to know.
         data_req_queued.send(()).unwrap_or(());

--- a/src/renderer_server/access_control.rs
+++ b/src/renderer_server/access_control.rs
@@ -89,268 +89,27 @@
 //! request cannot execute until the request before it is done. A request can't be done until it's
 //! at the front of all the queues it is in.
 
+mod data_guard;
+mod data_request;
+mod resources;
+
+pub use data_guard::*;
+pub use data_request::*;
+pub use resources::*;
+
 use std::sync::Arc;
-use std::collections::HashMap;
 
-use tokio::sync::{RwLock, Mutex, MutexGuard, Barrier, oneshot, mpsc};
-//TODO: Replace this with a `tokio` equivalent when tokio-rs/tokio#2478 is resolved:
-//  https://github.com/tokio-rs/tokio/issues/2478
-use futures_util::future::join_all;
+use tokio::sync::{Mutex, oneshot};
 
-use super::state::DrawingState;
-use super::app::{App, TurtleDrawings, TurtleId};
-
-#[derive(Debug, Clone)]
-pub enum RequiredTurtles {
-    // NOTE: using "One" or "Two" instead of something more general like "Some(Vec<TurtleId>)"
-    // allows common cases to avoid doing a bunch of small heap allocations. This enum can be
-    // extended as necessary depending on how many turtles are required in the future. If a truly
-    // variable number of turtles is needed for a request, it is fine to add a
-    // "Some(Vec<TurtieId>)" variant to this enum.
-
-    /// Request access to one turtle
-    One(TurtleId),
-
-    /// Request access to two turtles
-    ///
-    /// Note that if the two IDs are the same, this will cause a deadlock.
-    #[allow(dead_code)] //TODO(#16): This will be used for the multiple turtles feature (for Turtle::clone())
-    Two(TurtleId, TurtleId),
-
-    /// Request access to all the turtles that exist at the current time
-    ///
-    /// Even if more turtles are added while the waiting for access, this will still only provide
-    /// the turtles that existed when the `get()` call was first processed.
-    All,
-}
-
-impl RequiredTurtles {
-    /// Returns the number of turtles required, up to the provided total number of turtles
-    pub fn len(&self, turtles_len: usize) -> usize {
-        use RequiredTurtles::*;
-        match self {
-            One(_) => 1,
-            Two(_, _) => 2,
-            All => turtles_len,
-        }
-    }
-}
-
-#[derive(Default, Debug, Clone)]
-pub struct RequiredData {
-    /// If true, the drawing state will be locked and provided in the data
-    pub drawing: bool,
-
-    /// Requests access to none, some, or all of the turtles
-    pub turtles: Option<RequiredTurtles>,
-}
-
-/// Provides access to turtles
-///
-/// Due to some limitations of the locking APIs, these are not provided as lock guards. Each turtle
-/// must be locked before it can be used. It is guaranteed that no other call to `get()` through
-/// `AccessControl` will have access to the same turtles, so the locking should be uncontended. The
-/// only caveat is that the renderer may have locked all of the turtles, so the command may have to
-/// wait for that operation to complete.
-///
-/// This "limitation" turns out to be convenient, as it allows turtle locks to be unlocked
-/// temporarily during an animation. This unlocking is critical, as without it the renderer could
-/// not draw while an animation was taking place.
-#[derive(Debug)]
-enum Turtles {
-    // NOTE: A similar note to the one on `RequiredTurtles` applies here too
-
-    /// Access to a single turtle
-    One(Arc<Mutex<TurtleDrawings>>),
-
-    /// Access to two turtles
-    Two(Arc<Mutex<TurtleDrawings>>, Arc<Mutex<TurtleDrawings>>),
-
-    /// Access to all the turtles
-    All(Vec<Arc<Mutex<TurtleDrawings>>>),
-}
-
-#[derive(Debug)]
-pub enum TurtlesGuard<'a> {
-    // NOTE: A similar note to the one on `RequiredTurtles` applies here too
-
-    /// Access to a single turtle
-    One(MutexGuard<'a, TurtleDrawings>),
-
-    /// Access to two turtles
-    Two(MutexGuard<'a, TurtleDrawings>, MutexGuard<'a, TurtleDrawings>),
-
-    /// Access to all the turtles
-    All(Vec<MutexGuard<'a, TurtleDrawings>>),
-}
-
-impl<'a> TurtlesGuard<'a> {
-    pub fn one_mut(&mut self) -> &mut TurtleDrawings {
-        use TurtlesGuard::*;
-        match self {
-            One(turtle) => turtle,
-            _ => unreachable!("bug: expected exactly one turtle"),
-        }
-    }
-
-    #[allow(dead_code)] //TODO(#16): This will be used for the multiple turtles feature (for Turtle::clone())
-    pub fn two_mut(&mut self) -> (&mut TurtleDrawings, &mut TurtleDrawings) {
-        use TurtlesGuard::*;
-        match self {
-            Two(turtle1, turtle2) => (turtle1, turtle2),
-            _ => unreachable!("bug: expected exactly two turtles"),
-        }
-    }
-
-    pub fn all_mut(&mut self) -> &mut [MutexGuard<'a, TurtleDrawings>] {
-        use TurtlesGuard::*;
-        match self {
-            All(turtles) => turtles,
-            _ => unreachable!("bug: expected all of the turtles"),
-        }
-    }
-}
-
-/// A locked version of all the required data once it is ready
-#[derive(Debug)]
-pub struct DataGuard<'a> {
-    /// If `RequiredData::drawing` was true, this field will contain the locked drawing state
-    drawing: Option<MutexGuard<'a, DrawingState>>,
-
-    /// The turtles requested in `RequiredData::turtles`
-    turtles: Option<Turtles>,
-
-    /// Channel to report to when the data guard is dropped
-    operation_complete_sender: Option<oneshot::Sender<()>>,
-}
-
-impl<'a> Drop for DataGuard<'a> {
-    fn drop(&mut self) {
-        // unwrap() is safe because a struct cannot be dropped twice
-        let sender = self.operation_complete_sender.take().unwrap();
-        // There are some cases (e.g. a panic) where AccessControl can get dropped before
-        // DataGuard. In that case, the send might fail and we can just ignore that. This should
-        // never fail otherwise because the tasks managing access to data should run forever.
-        sender.send(()).unwrap_or(())
-    }
-}
-
-impl<'a> DataGuard<'a> {
-    /// Gets a mutable reference to the drawing state or panics if it was not requested in `get()`
-    pub fn drawing_mut(&mut self) -> &mut DrawingState {
-        self.drawing.as_mut()
-            .expect("bug: attempt to fetch drawing when it was not requested")
-    }
-
-    /// Gets the mutable locked turtles that were requested or panics if none were requested
-    pub async fn turtles_mut(&mut self) -> TurtlesGuard<'_> {
-        let turtles = self.turtles.as_mut()
-            .expect("bug: attempt to fetch turtles when none were requested");
-
-        use Turtles::*;
-        match turtles {
-            One(turtle) => TurtlesGuard::One(turtle.lock().await),
-            Two(turtle1, turtle2) => {
-                let (turtle1, turtle2) = tokio::join!(turtle1.lock(), turtle2.lock());
-                TurtlesGuard::Two(turtle1, turtle2)
-            },
-            All(turtles) => TurtlesGuard::All(join_all(turtles.iter().map(|t| t.lock())).await),
-        }
-    }
-}
-
-/// Represents a request for access to a resource
-///
-/// Note that due to lifetime limitations, this does not manage sending the resource back to the
-/// task waiting for access to it. It only acts to signal that the resource is ready to be
-/// accessed.
-#[derive(Debug)]
-struct DataRequest {
-    /// A barrier that all tasks will wait at before signaling that data is ready
-    ///
-    /// This ensures that all the requested data must be ready before proceeding to lock any of it
-    all_data_ready_barrier: Arc<Barrier>,
-
-    /// This barrier must have the same size as the `data_ready` barrier and is used to ensure that
-    /// access to all of the data ends at the same time. This is necessary since only a single data
-    /// channel (the leader) is ever aware that the data is no longer being accessed. That channel
-    /// will be the last one to wait at this barrier and thus all of the data will become available
-    /// again at the same time.
-    all_complete_barrier: Arc<Barrier>,
-
-    /// Used to signal the task waiting for data that the data is ready
-    ///
-    /// Only a single data channel (the leader) will use this field. That channel will then send a
-    /// oneshot channel that will be used to indicate when the data is no longer going to be used.
-    data_ready: Arc<Mutex<Option<oneshot::Sender<oneshot::Sender<()>>>>>,
-}
-
-/// Provides the ability to communicate with a task that manages access to a particular resource
-#[derive(Debug)]
-struct DataChannel {
-    sender: mpsc::UnboundedSender<DataRequest>,
-}
-
-impl DataChannel {
-    pub fn spawn() -> Self {
-        let (sender, mut req_receiver) = mpsc::unbounded_channel();
-
-        tokio::spawn(async move {
-            // Run until recv() fails since that means that the main access control task has quit
-            while let Some(req) = req_receiver.recv().await {
-                let DataRequest {all_data_ready_barrier, all_complete_barrier, data_ready} = req;
-
-                // Wait until all of the data is ready at the same time
-                let res = all_data_ready_barrier.wait().await;
-
-                if res.is_leader() {
-                    // Notify that the data is ready
-                    let data_ready = data_ready.lock().await.take()
-                        .expect("only the leader should use the data ready channel");
-
-                    let (operation_complete, complete_receiver) = oneshot::channel();
-
-                    // Wait until the data has been dropped and will no longer be used
-                    //
-                    // Ignoring error because even if this fails, it just means that the future
-                    // holding the data was dropped. In that case, the data is still now available
-                    // again for the next task waiting for it.
-                    data_ready.send(operation_complete).unwrap_or(());
-
-                    // Even though only a single task is waiting on this channel, all of the tasks
-                    // will wait on the barrier below until the data is no longer being used.
-                    //
-                    // Ignoring error because if this fails it could just be that the future
-                    // waiting for the `operation_complete` channel was dropped. In that case, the
-                    // data is still available again for the next task waiting for it.
-                    complete_receiver.await.unwrap_or(());
-                }
-
-                // Wait for all of the data to stop being used before processing the next request
-                //
-                // This barrier must eventually be reached no matter what happens above. If all
-                // data channels do not get to this point we can get into a situation where nothing
-                // can make progress.
-                all_complete_barrier.wait().await;
-            }
-        });
-
-        Self {sender}
-    }
-
-    pub fn send(&self, req: DataRequest) {
-        self.sender.send(req)
-            .expect("bug: tasks managing access to data should run forever");
-    }
-}
+use super::app::{App, TurtleId};
 
 /// Manages access to the app state, enforcing the rules around sequential consistency and
 /// concurrent access
 #[derive(Debug)]
 pub struct AccessControl {
     app: Arc<App>,
-    drawing_channel: DataChannel,
-    turtle_channels: RwLock<HashMap<TurtleId, DataChannel>>,
+    resources: Arc<Mutex<Resources>>,
+    resource_manager: ResourceManager,
 }
 
 impl AccessControl {
@@ -362,10 +121,13 @@ impl AccessControl {
         assert_eq!(app.turtles_len().await, 0,
             "bug: access control assumes that turtles are only added through itself");
 
+        let resources = Arc::new(Mutex::new(Resources::default()));
+        let resource_manager = ResourceManager::new(resources.clone());
+
         Self {
             app,
-            drawing_channel: DataChannel::spawn(),
-            turtle_channels: Default::default(),
+            resources,
+            resource_manager,
         }
     }
 
@@ -376,92 +138,66 @@ impl AccessControl {
     pub async fn add_turtle(&self) -> TurtleId {
         let id = self.app.add_turtle().await;
 
-        let mut turtle_channels = self.turtle_channels.write().await;
-        turtle_channels.insert(id, DataChannel::spawn());
-
         id
     }
 
-    /// Requests the opportunity to potentially read or modify all turtles
+    /// Requests the opportunity to potentially read or modify the drawing and all turtles
     ///
-    /// A message will be sent through `data_req_queued` when the data requests have been queued and
-    /// the next call to get() may proceed.
-    pub async fn get(
+    /// See `get()` for more information
+    pub async fn get_all(&self, data_req_queued: oneshot::Sender<()>) -> (DrawingData, Vec<TurtleData>) {
+        // Record the IDs of the turtles that are currently available. This is necessary to
+        // guarantee the soundness of requesting "all" of the turtles. No request is allowed to
+        // depend on turtles that haven't been created yet, so "all" must be treated as all turtles
+        // that currently exist when the request was sent. Only those turtles will be accessed, even
+        // if more are added while the request waits.
+        let turtles: Vec<_> = self.app.turtle_ids().await.collect();
+
+        self.get((FetchDrawing, turtles), data_req_queued).await
+    }
+
+    /// Requests the opportunity to potentially read or modify the drawing
+    ///
+    /// See `get()` for more information
+    pub async fn get_drawing(&self, data_req_queued: oneshot::Sender<()>) -> DrawingData {
+        self.get(FetchDrawing, data_req_queued).await
+    }
+
+    /// Requests the opportunity to potentially read or modify some of the
+    /// application state
+    ///
+    /// A message will be sent through `data_req_queued` when the data requests
+    /// have been queued and the next call to get() may proceed.
+    ///
+    /// # Deadlock Warning
+    ///
+    /// **Warning:** If used incorrectly, this method can deadlock the program. For example, if the
+    /// same resource is requested twice, one of the requests will be fulfilled, but the other will
+    /// cause a deadlock since the same resource cannot be held twice.
+    pub async fn get<R: DataRequest>(
         &self,
-        req_data: RequiredData,
+        data_req: R,
         data_req_queued: oneshot::Sender<()>,
-    ) -> DataGuard<'_> {
-        let RequiredData {drawing, turtles} = req_data;
+    ) -> <R as DataRequest>::Output {
+        // Request all the necessary data
 
-        //TODO: Explore if there is a different formulation of this struct that is simpler but
-        // still accomplishes all of the same goals.
-
-        let turtles_len = self.app.turtles_len().await;
-        let req_turtles = turtles.as_ref().map(|ts| ts.len(turtles_len)).unwrap_or(0);
-
-        // Calculate the total number of data tasks that we will request access from
-        let total_reqs = if drawing { 1 } else { 0 } + req_turtles;
-
-        // Send data requests to the tasks managing access to all the requested data
-
-        let all_data_ready_barrier = Arc::new(Barrier::new(total_reqs));
-        let all_complete_barrier = Arc::new(Barrier::new(total_reqs));
-        let (data_ready, data_ready_receiver) = oneshot::channel();
-        let data_ready = Arc::new(Mutex::new(Some(data_ready)));
-
-        if drawing {
-            self.drawing_channel.send(DataRequest {
-                all_data_ready_barrier: all_data_ready_barrier.clone(),
-                all_complete_barrier: all_complete_barrier.clone(),
-                data_ready: data_ready.clone(),
-            });
-        }
-
-        // Record the IDs that are currently available at the time that data is requested. This is
-        // necessary to guarantee the soundness of `RequiredTurtles::All`. No request is allowed to
-        // depend on turtles that haven't been created yet, so `All` must be treated as all turtles
-        // that currently exist when the request was sent. Only those turtles will be accessed,
-        // even if more are added while the request waits.
-        let ids = self.app.turtle_ids().await;
-
-        use RequiredTurtles::*;
-        match &turtles {
-            &Some(One(id)) => {
-                let channels = self.turtle_channels.read().await;
-                channels[&id].send(DataRequest {
-                    all_data_ready_barrier: all_data_ready_barrier.clone(),
-                    all_complete_barrier: all_complete_barrier.clone(),
-                    data_ready: data_ready.clone(),
-                });
+        let mut pending_request: Option<(Arc<PendingDataRequest>, _)> = None;
+        let generate_data_request = || match &pending_request {
+            Some((req, _)) => {
+                req.add_needed_resource();
+                req.clone()
             },
 
-            &Some(Two(id1, id2)) => {
-                let channels = self.turtle_channels.read().await;
-                channels[&id1].send(DataRequest {
-                    all_data_ready_barrier: all_data_ready_barrier.clone(),
-                    all_complete_barrier: all_complete_barrier.clone(),
-                    data_ready: data_ready.clone(),
-                });
-
-                channels[&id2].send(DataRequest {
-                    all_data_ready_barrier: all_data_ready_barrier.clone(),
-                    all_complete_barrier: all_complete_barrier.clone(),
-                    data_ready: data_ready.clone(),
-                });
+            None => {
+                let (sender, receiver) = oneshot::channel();
+                let req = Arc::new(PendingDataRequest::new(sender));
+                pending_request = Some((req.clone(), receiver));
+                req
             },
+        };
 
-            Some(All) => {
-                let channels = self.turtle_channels.read().await;
-                for id in ids.clone() {
-                    channels[&id].send(DataRequest {
-                        all_data_ready_barrier: all_data_ready_barrier.clone(),
-                        all_complete_barrier: all_complete_barrier.clone(),
-                        data_ready: data_ready.clone(),
-                    });
-                }
-            },
-
-            None => {},
+        {
+            let mut res = self.resources.lock().await;
+            data_req.poll_resources(&mut res, generate_data_request);
         }
 
         // Signal that all data requests have been queued and the next call to get() can proceed.
@@ -474,46 +210,14 @@ impl AccessControl {
         // requests have been queued no longer needs to know.
         data_req_queued.send(()).unwrap_or(());
 
-        // Now wait for data ready channel to signal that data is ready
-        let operation_complete_sender = data_ready_receiver.await
-            .expect("bug: tasks managing access to data should run forever");
+        // Wait for any data that is not available yet
+        if let Some((_, data_ready_receiver)) = pending_request {
+            data_ready_receiver.await
+                .expect("bug: tasks should notify about data being available before they are dropped");
+        }
 
-        // Lock all the data that was requested (should only be contended by renderer)
+        // Fetch all the data that was requested (should only be contended by renderer)
 
-        // NOTE: To avoid deadlocking, all of the code follows a consistent locking order:
-        //
-        // 1. drawing.lock() (done below)
-        // 2. turtles.lock() (done partially here and then in handler code)
-        // 3. display_list.lock() (done in handler code as-needed)
-        // 4. event_loop.lock() (done in handler code as-needed)
-        //
-        // Any of these steps may be omitted, but the order must always be consistent.
-
-        let drawing = if drawing {
-            let drawing = self.app.drawing_mut().await;
-            Some(drawing)
-        } else { None };
-
-        let turtles = match turtles {
-            Some(One(id)) => {
-                let turtle = self.app.turtle(id).await;
-                Some(Turtles::One(turtle))
-            },
-
-            Some(Two(id1, id2)) => {
-                let (turtle1, turtle2) = tokio::join!(self.app.turtle(id1), self.app.turtle(id2));
-                Some(Turtles::Two(turtle1, turtle2))
-            },
-
-            Some(All) => {
-                let turtles = join_all(ids.map(|id| self.app.turtle(id))).await;
-                Some(Turtles::All(turtles))
-            },
-
-            None => None,
-        };
-
-        let operation_complete_sender = Some(operation_complete_sender);
-        DataGuard {drawing, turtles, operation_complete_sender}
+        data_req.fetch_resources(&self.app, &self.resource_manager).await
     }
 }

--- a/src/renderer_server/access_control.rs
+++ b/src/renderer_server/access_control.rs
@@ -104,6 +104,11 @@ use parking_lot::Mutex;
 
 use super::app::{App, TurtleId};
 
+// Note: It is important that all of the resources be protected together by a Mutex rather than
+// individually on a per-resource basis. This is how we guarantee that if a request needs multiple
+// resources, it is able to reserve them all at once. Without that, two requests could race to
+// reserve the same resources and end up deadlocked because the requests were queued in the wrong
+// order.
 type SharedResources = Arc<Mutex<Resources>>;
 
 /// Manages access to the app state, enforcing the rules around sequential consistency and

--- a/src/renderer_server/access_control/data_guard.rs
+++ b/src/renderer_server/access_control/data_guard.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
-use tokio::sync::{MutexGuard, Mutex, mpsc};
+use tokio::sync::{Mutex, MutexGuard};
 
 use super::super::{
     app::{TurtleDrawings, TurtleId},
     state::DrawingState,
 };
 
-use super::Resources;
+use super::SharedResources;
 
 pub type TurtleDataGuard<'a> = MutexGuard<'a, TurtleDrawings>;
 
@@ -15,7 +15,7 @@ pub type TurtleDataGuard<'a> = MutexGuard<'a, TurtleDrawings>;
 pub struct TurtleData {
     pub(in super) id: TurtleId,
     pub(in super) turtle: Arc<Mutex<TurtleDrawings>>,
-    pub(in super) resource_manager: ResourceManager,
+    pub(in super) resources: SharedResources,
 }
 
 impl TurtleData {
@@ -26,7 +26,7 @@ impl TurtleData {
 
 impl Drop for TurtleData {
     fn drop(&mut self) {
-        self.resource_manager.free_turtle(self.id);
+        self.resources.lock().turtle(self.id).free();
     }
 }
 
@@ -43,7 +43,7 @@ pub type DrawingDataGuard<'a> = MutexGuard<'a, DrawingState>;
 #[derive(Debug)]
 pub struct DrawingData {
     pub(in super) drawing: Arc<Mutex<DrawingState>>,
-    pub(in super) resource_manager: ResourceManager,
+    pub(in super) resources: SharedResources,
 }
 
 impl DrawingData {
@@ -54,65 +54,6 @@ impl DrawingData {
 
 impl Drop for DrawingData {
     fn drop(&mut self) {
-        self.resource_manager.free_drawing();
-    }
-}
-
-#[derive(Debug, Clone)]
-enum FreeResource {
-    /// Report that the drawing is now free for use
-    Drawing,
-
-    /// Report that the given turtle is now free for use
-    Turtle(TurtleId),
-}
-
-/// An asynchronous task that manages freeing resources once they are no longer being used
-///
-/// This exists because you can't run asynchronous code in Drop, but you can send a message over a
-/// channel.
-#[derive(Debug, Clone)]
-pub struct ResourceManager {
-    sender: mpsc::UnboundedSender<FreeResource>,
-}
-
-impl ResourceManager {
-    pub fn new(res: Arc<Mutex<Resources>>) -> Self {
-        let (sender, mut receiver) = mpsc::unbounded_channel();
-
-        tokio::spawn(async move {
-            let handle_free = |res: &mut Resources, free_res| {
-                match free_res {
-                    FreeResource::Drawing => res.drawing().free(),
-
-                    FreeResource::Turtle(id) => {
-                        res.turtle(id).free();
-                    },
-                }
-            };
-
-            // The thread will exit once no more messages will ever be received
-            while let Some(free_res) = receiver.recv().await {
-                let mut res = res.lock().await;
-                handle_free(&mut res, free_res);
-
-                // Handle as many other messages as we can while we're still holding on to the lock
-                while let Ok(free_res) = receiver.try_recv() {
-                    handle_free(&mut res, free_res);
-                }
-            }
-        });
-
-        Self {sender}
-    }
-
-    pub fn free_drawing(&self) {
-        self.sender.send(FreeResource::Drawing)
-            .expect("bug: resource manager task should outlive notifiers");
-    }
-
-    pub fn free_turtle(&self, id: TurtleId) {
-        self.sender.send(FreeResource::Turtle(id))
-            .expect("bug: resource manager task should outlive notifiers");
+        self.resources.lock().drawing().free();
     }
 }

--- a/src/renderer_server/access_control/data_guard.rs
+++ b/src/renderer_server/access_control/data_guard.rs
@@ -1,0 +1,118 @@
+use std::sync::Arc;
+
+use tokio::sync::{MutexGuard, Mutex, mpsc};
+
+use super::super::{
+    app::{TurtleDrawings, TurtleId},
+    state::DrawingState,
+};
+
+use super::Resources;
+
+pub type TurtleDataGuard<'a> = MutexGuard<'a, TurtleDrawings>;
+
+#[derive(Debug)]
+pub struct TurtleData {
+    pub(in super) id: TurtleId,
+    pub(in super) turtle: Arc<Mutex<TurtleDrawings>>,
+    pub(in super) resource_manager: ResourceManager,
+}
+
+impl TurtleData {
+    pub async fn lock(&self) -> TurtleDataGuard<'_> {
+        self.turtle.lock().await
+    }
+}
+
+impl Drop for TurtleData {
+    fn drop(&mut self) {
+        self.resource_manager.free_turtle(self.id);
+    }
+}
+
+pub async fn lock_turtles(turtles: &[TurtleData]) -> Vec<TurtleDataGuard<'_>> {
+    //TODO: Replace this with a `tokio` equivalent when tokio-rs/tokio#2478 is resolved:
+    //  https://github.com/tokio-rs/tokio/issues/2478
+    use futures_util::future::join_all;
+
+    join_all(turtles.iter().map(|turtle| turtle.lock())).await
+}
+
+pub type DrawingDataGuard<'a> = MutexGuard<'a, DrawingState>;
+
+#[derive(Debug)]
+pub struct DrawingData {
+    pub(in super) drawing: Arc<Mutex<DrawingState>>,
+    pub(in super) resource_manager: ResourceManager,
+}
+
+impl DrawingData {
+    pub async fn lock(&self) -> DrawingDataGuard<'_> {
+        self.drawing.lock().await
+    }
+}
+
+impl Drop for DrawingData {
+    fn drop(&mut self) {
+        self.resource_manager.free_drawing();
+    }
+}
+
+#[derive(Debug, Clone)]
+enum FreeResource {
+    /// Report that the drawing is now free for use
+    Drawing,
+
+    /// Report that the given turtle is now free for use
+    Turtle(TurtleId),
+}
+
+/// An asynchronous task that manages freeing resources once they are no longer being used
+///
+/// This exists because you can't run asynchronous code in Drop, but you can send a message over a
+/// channel.
+#[derive(Debug, Clone)]
+pub struct ResourceManager {
+    sender: mpsc::UnboundedSender<FreeResource>,
+}
+
+impl ResourceManager {
+    pub fn new(res: Arc<Mutex<Resources>>) -> Self {
+        let (sender, mut receiver) = mpsc::unbounded_channel();
+
+        tokio::spawn(async move {
+            let handle_free = |res: &mut Resources, free_res| {
+                match free_res {
+                    FreeResource::Drawing => res.drawing().free(),
+
+                    FreeResource::Turtle(id) => {
+                        res.turtle(id).free();
+                    },
+                }
+            };
+
+            // The thread will exit once no more messages will ever be received
+            while let Some(free_res) = receiver.recv().await {
+                let mut res = res.lock().await;
+                handle_free(&mut res, free_res);
+
+                // Handle as many other messages as we can while we're still holding on to the lock
+                while let Ok(free_res) = receiver.try_recv() {
+                    handle_free(&mut res, free_res);
+                }
+            }
+        });
+
+        Self {sender}
+    }
+
+    pub fn free_drawing(&self) {
+        self.sender.send(FreeResource::Drawing)
+            .expect("bug: resource manager task should outlive notifiers");
+    }
+
+    pub fn free_turtle(&self, id: TurtleId) {
+        self.sender.send(FreeResource::Turtle(id))
+            .expect("bug: resource manager task should outlive notifiers");
+    }
+}

--- a/src/renderer_server/access_control/data_request.rs
+++ b/src/renderer_server/access_control/data_request.rs
@@ -2,7 +2,7 @@ use std::{future::Future, sync::Arc, pin::Pin};
 
 use futures_util::future;
 
-use super::{DrawingData, TurtleData, Resources, PendingDataRequest, ResourceManager};
+use super::{DrawingData, TurtleData, Resources, PendingDataRequest, SharedResources};
 
 use super::super::app::{App, TurtleId};
 
@@ -16,31 +16,31 @@ pub trait DataRequest {
     /// available. Every call to that function will increment the number of resources being waited
     /// for. If this method is called, the request will wait for all resources to become available
     /// before proceeding.
-    fn poll_resources<F>(&self, res: &mut Resources, generate_data_request: F)
-    where F: FnMut() -> Arc<PendingDataRequest>;
+    fn poll_resources<F>(&self, resources: &mut Resources, generate_data_request: F)
+        where F: FnMut() -> Arc<PendingDataRequest>;
 
     /// Assuming that the requested resources are now available, this method retrieves them
     //TODO: This can become an async trait method once those are supported by the compiler
-    fn fetch_resources<'a>(&'a self, app: &'a App, resource_manager: &'a ResourceManager) -> Pin<Box<dyn Future<Output=Self::Output> + Send + 'a>>;
+    fn fetch_resources<'a>(&'a self, app: &'a App, resources: &'a SharedResources) -> Pin<Box<dyn Future<Output=Self::Output> + Send + 'a>>;
 }
 
 // This is used for the multiple turtles feature (for Turtle::clone())
 impl<T: DataRequest, U: DataRequest> DataRequest for (T, U) {
     type Output = (<T as DataRequest>::Output, <U as DataRequest>::Output);
 
-    fn poll_resources<F>(&self, res: &mut Resources, mut generate_data_request: F)
+    fn poll_resources<F>(&self, resources: &mut Resources, mut generate_data_request: F)
         where F: FnMut() -> Arc<PendingDataRequest>
     {
         let (req1, req2) = self;
-        req1.poll_resources(res, &mut generate_data_request);
-        req2.poll_resources(res, &mut generate_data_request);
+        req1.poll_resources(resources, &mut generate_data_request);
+        req2.poll_resources(resources, &mut generate_data_request);
     }
 
-    fn fetch_resources<'a>(&'a self, app: &'a App, resource_manager: &'a ResourceManager) -> Pin<Box<dyn Future<Output=Self::Output> + Send + 'a>> {
+    fn fetch_resources<'a>(&'a self, app: &'a App, resources: &'a SharedResources) -> Pin<Box<dyn Future<Output=Self::Output> + Send + 'a>> {
         let (req1, req2) = self;
         Box::pin(future::join(
-            req1.fetch_resources(app, resource_manager),
-            req2.fetch_resources(app, resource_manager),
+            req1.fetch_resources(app, resources),
+            req2.fetch_resources(app, resources),
         ))
     }
 }
@@ -48,26 +48,26 @@ impl<T: DataRequest, U: DataRequest> DataRequest for (T, U) {
 impl<T: DataRequest> DataRequest for Vec<T> {
     type Output = Vec<<T as DataRequest>::Output>;
 
-    fn poll_resources<F>(&self, res: &mut Resources, mut generate_data_request: F)
+    fn poll_resources<F>(&self, resources: &mut Resources, mut generate_data_request: F)
         where F: FnMut() -> Arc<PendingDataRequest>
     {
         for req in self {
-            req.poll_resources(res, &mut generate_data_request);
+            req.poll_resources(resources, &mut generate_data_request);
         }
     }
 
-    fn fetch_resources<'a>(&'a self, app: &'a App, resource_manager: &'a ResourceManager) -> Pin<Box<dyn Future<Output=Self::Output> + Send + 'a>> {
-        Box::pin(future::join_all(self.iter().map(|req| req.fetch_resources(app, resource_manager))))
+    fn fetch_resources<'a>(&'a self, app: &'a App, resources: &'a SharedResources) -> Pin<Box<dyn Future<Output=Self::Output> + Send + 'a>> {
+        Box::pin(future::join_all(self.iter().map(|req| req.fetch_resources(app, resources))))
     }
 }
 
 impl DataRequest for TurtleId {
     type Output = TurtleData;
 
-    fn poll_resources<F>(&self, res: &mut Resources, mut generate_data_request: F)
+    fn poll_resources<F>(&self, resources: &mut Resources, mut generate_data_request: F)
         where F: FnMut() -> Arc<PendingDataRequest>
     {
-        let turtle_res = res.turtle(*self);
+        let turtle_res = resources.turtle(*self);
         if turtle_res.is_available() {
             turtle_res.reserve();
         } else {
@@ -75,7 +75,7 @@ impl DataRequest for TurtleId {
         }
     }
 
-    fn fetch_resources<'a>(&'a self, app: &'a App, resource_manager: &'a ResourceManager) -> Pin<Box<dyn Future<Output=Self::Output> + Send + 'a>> {
+    fn fetch_resources<'a>(&'a self, app: &'a App, resources: &'a SharedResources) -> Pin<Box<dyn Future<Output=Self::Output> + Send + 'a>> {
         use futures_util::FutureExt;
 
         let id = *self;
@@ -83,7 +83,7 @@ impl DataRequest for TurtleId {
         Box::pin(app.turtle(id).map(move |turtle| TurtleData {
             id,
             turtle,
-            resource_manager: resource_manager.clone(),
+            resources: resources.clone(),
         }))
     }
 }
@@ -97,10 +97,10 @@ pub struct FetchDrawing;
 impl DataRequest for FetchDrawing {
     type Output = DrawingData;
 
-    fn poll_resources<F>(&self, res: &mut Resources, mut generate_data_request: F)
+    fn poll_resources<F>(&self, resources: &mut Resources, mut generate_data_request: F)
         where F: FnMut() -> Arc<PendingDataRequest>
     {
-        let drawing_res = res.drawing();
+        let drawing_res = resources.drawing();
         if drawing_res.is_available() {
             drawing_res.reserve();
         } else {
@@ -108,10 +108,10 @@ impl DataRequest for FetchDrawing {
         }
     }
 
-    fn fetch_resources<'a>(&'a self, app: &'a App, resource_manager: &'a ResourceManager) -> Pin<Box<dyn Future<Output=Self::Output> + Send + 'a>> {
+    fn fetch_resources<'a>(&'a self, app: &'a App, resources: &'a SharedResources) -> Pin<Box<dyn Future<Output=Self::Output> + Send + 'a>> {
         Box::pin(future::ready(DrawingData {
             drawing: app.drawing().clone(),
-            resource_manager: resource_manager.clone(),
+            resources: resources.clone(),
         }))
     }
 }

--- a/src/renderer_server/access_control/data_request.rs
+++ b/src/renderer_server/access_control/data_request.rs
@@ -1,0 +1,117 @@
+use std::{future::Future, sync::Arc, pin::Pin};
+
+use futures_util::future;
+
+use super::{DrawingData, TurtleData, Resources, PendingDataRequest, ResourceManager};
+
+use super::super::app::{App, TurtleId};
+
+pub trait DataRequest {
+    /// The type returned when the request is fulfilled
+    type Output: Send;
+
+    /// Attempt to reserve all the resources needed to fulfill this request
+    ///
+    /// `generate_data_request` should only be called if one of the required resources is not
+    /// available. Every call to that function will increment the number of resources being waited
+    /// for. If this method is called, the request will wait for all resources to become available
+    /// before proceeding.
+    fn poll_resources<F>(&self, res: &mut Resources, generate_data_request: F)
+    where F: FnMut() -> Arc<PendingDataRequest>;
+
+    /// Assuming that the requested resources are now available, this method retrieves them
+    //TODO: This can become an async trait method once those are supported by the compiler
+    fn fetch_resources<'a>(&'a self, app: &'a App, resource_manager: &'a ResourceManager) -> Pin<Box<dyn Future<Output=Self::Output> + Send + 'a>>;
+}
+
+// This is used for the multiple turtles feature (for Turtle::clone())
+impl<T: DataRequest, U: DataRequest> DataRequest for (T, U) {
+    type Output = (<T as DataRequest>::Output, <U as DataRequest>::Output);
+
+    fn poll_resources<F>(&self, res: &mut Resources, mut generate_data_request: F)
+        where F: FnMut() -> Arc<PendingDataRequest>
+    {
+        let (req1, req2) = self;
+        req1.poll_resources(res, &mut generate_data_request);
+        req2.poll_resources(res, &mut generate_data_request);
+    }
+
+    fn fetch_resources<'a>(&'a self, app: &'a App, resource_manager: &'a ResourceManager) -> Pin<Box<dyn Future<Output=Self::Output> + Send + 'a>> {
+        let (req1, req2) = self;
+        Box::pin(future::join(
+            req1.fetch_resources(app, resource_manager),
+            req2.fetch_resources(app, resource_manager),
+        ))
+    }
+}
+
+impl<T: DataRequest> DataRequest for Vec<T> {
+    type Output = Vec<<T as DataRequest>::Output>;
+
+    fn poll_resources<F>(&self, res: &mut Resources, mut generate_data_request: F)
+        where F: FnMut() -> Arc<PendingDataRequest>
+    {
+        for req in self {
+            req.poll_resources(res, &mut generate_data_request);
+        }
+    }
+
+    fn fetch_resources<'a>(&'a self, app: &'a App, resource_manager: &'a ResourceManager) -> Pin<Box<dyn Future<Output=Self::Output> + Send + 'a>> {
+        Box::pin(future::join_all(self.iter().map(|req| req.fetch_resources(app, resource_manager))))
+    }
+}
+
+impl DataRequest for TurtleId {
+    type Output = TurtleData;
+
+    fn poll_resources<F>(&self, res: &mut Resources, mut generate_data_request: F)
+        where F: FnMut() -> Arc<PendingDataRequest>
+    {
+        let turtle_res = res.turtle(*self);
+        if turtle_res.is_available() {
+            turtle_res.reserve();
+        } else {
+            turtle_res.push_data_request(generate_data_request());
+        }
+    }
+
+    fn fetch_resources<'a>(&'a self, app: &'a App, resource_manager: &'a ResourceManager) -> Pin<Box<dyn Future<Output=Self::Output> + Send + 'a>> {
+        use futures_util::FutureExt;
+
+        let id = *self;
+
+        Box::pin(app.turtle(id).map(move |turtle| TurtleData {
+            id,
+            turtle,
+            resource_manager: resource_manager.clone(),
+        }))
+    }
+}
+
+/// A placeholder struct that makes it possible to request the drawing
+///
+/// Makes it possible to request the drawing
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FetchDrawing;
+
+impl DataRequest for FetchDrawing {
+    type Output = DrawingData;
+
+    fn poll_resources<F>(&self, res: &mut Resources, mut generate_data_request: F)
+        where F: FnMut() -> Arc<PendingDataRequest>
+    {
+        let drawing_res = res.drawing();
+        if drawing_res.is_available() {
+            drawing_res.reserve();
+        } else {
+            drawing_res.push_data_request(generate_data_request());
+        }
+    }
+
+    fn fetch_resources<'a>(&'a self, app: &'a App, resource_manager: &'a ResourceManager) -> Pin<Box<dyn Future<Output=Self::Output> + Send + 'a>> {
+        Box::pin(future::ready(DrawingData {
+            drawing: app.drawing().clone(),
+            resource_manager: resource_manager.clone(),
+        }))
+    }
+}

--- a/src/renderer_server/access_control/resources.rs
+++ b/src/renderer_server/access_control/resources.rs
@@ -1,0 +1,151 @@
+use std::sync::{Arc, Mutex, atomic::{AtomicUsize, Ordering}};
+use std::collections::{VecDeque, HashMap};
+
+use tokio::sync::oneshot;
+
+use super::super::app::TurtleId;
+
+// Using a synchronous Mutex since we don't need to keep it locked across await points
+#[derive(Debug)]
+pub struct DataReadyNotifier(Mutex<Option<oneshot::Sender<()>>>);
+
+impl DataReadyNotifier {
+    pub fn new(sender: oneshot::Sender<()>) -> Self {
+        DataReadyNotifier(Mutex::new(Some(sender)))
+    }
+
+    /// Signals that the data is ready
+    ///
+    /// This method will panic if called more than once
+    pub fn signal_ready(&self) {
+        let DataReadyNotifier(sender) = self;
+
+        // There are some cases (e.g. a panic) where AccessControl can get dropped before all of the
+        // DataReadyNotifiers. In that case, the lock or send might fail and we can just ignore it.
+        if let Ok(mut sender) = sender.lock() {
+            let sender = sender.take()
+                .expect("bug: only the last resource should notify that the data is ready");
+            sender.send(()).unwrap_or(())
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct PendingDataRequest {
+    /// The number of resources currently being waited on
+    ///
+    /// Once this counter hits zero, the data request has been fulfilled and all required resources
+    /// are available.
+    needed: AtomicUsize,
+
+    /// Used to signal the task waiting for data that the data is ready
+    ///
+    /// Only a the last resource being waited on will use this field.
+    data_ready: DataReadyNotifier,
+}
+
+impl PendingDataRequest {
+    /// Creates a new pending data request that is waiting for a single resource
+    pub fn new(sender: oneshot::Sender<()>) -> Self {
+        Self {
+            needed: AtomicUsize::new(1),
+            data_ready: DataReadyNotifier::new(sender),
+        }
+    }
+
+    /// Records that another resource is necessary for this request to be fulfilled
+    ///
+    /// Note: this method should not be called after a data request has finished polling resources.
+    pub fn add_needed_resource(&self) {
+        self.needed.fetch_add(1, Ordering::SeqCst);
+    }
+
+    /// Records that one of the resources pending for this request is now available
+    ///
+    /// Decrements the number of resources being waited for and signals that all of the data is
+    /// ready if this was the last resource being waited on.
+    pub fn resource_ready(&self) {
+        let prev_counter = self.needed.fetch_sub(1, Ordering::SeqCst);
+        debug_assert_ne!(prev_counter, 0, "bug: inconsistent counter for resource (overflow)");
+
+        let counter = prev_counter - 1;
+        if counter == 0 {
+            self.data_ready.signal_ready();
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Resource {
+    /// If false, the resource is currently being held and any requests must be queued
+    is_available: bool,
+    /// The pending data requests that could not be fulfilled because this resource was unavailable
+    pending: VecDeque<Arc<PendingDataRequest>>,
+}
+
+impl Default for Resource {
+    fn default() -> Self {
+        Self {
+            // All resources start out available since they have not been used yet
+            is_available: true,
+            pending: Default::default(),
+        }
+    }
+}
+
+impl Resource {
+    pub fn is_available(&self) -> bool {
+        self.is_available
+    }
+
+    pub fn push_data_request(&mut self, req: Arc<PendingDataRequest>) {
+        self.pending.push_back(req);
+    }
+
+    /// Reserves the resource, thus making it unavailable until it is freed
+    pub fn reserve(&mut self) {
+        debug_assert!(self.is_available, "bug: attempt to reserve resource that is currently unavailable");
+
+        self.is_available = false;
+    }
+
+    /// Frees this resource to the next pending request or marks it as available if no further
+    /// requests are waiting to be processed
+    ///
+    /// This method should only be used once the resource is no longer available to the previous
+    /// requestor
+    pub fn free(&mut self) {
+        debug_assert!(!self.is_available, "bug: attempt to free resource that is already available");
+
+        match self.pending.pop_front() {
+            Some(req) => {
+                req.resource_ready();
+
+                // Another request has claimed this resource, so it remains unavailable
+            },
+
+            None => {
+                // No other request needs this resource, so it is now available
+                self.is_available = true;
+            },
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Resources {
+    /// Controls access to the drawing
+    drawing: Resource,
+    /// Controls access to the turtles
+    turtles: HashMap<TurtleId, Resource>,
+}
+
+impl Resources {
+    pub fn drawing(&mut self) -> &mut Resource {
+        &mut self.drawing
+    }
+
+    pub fn turtle(&mut self, id: TurtleId) -> &mut Resource {
+        self.turtles.entry(id).or_default()
+    }
+}

--- a/src/renderer_server/app.rs
+++ b/src/renderer_server/app.rs
@@ -63,6 +63,7 @@ impl App {
     }
 
     /// Returns a mutable handle to the drawing state
+    #[cfg_attr(feature = "test", allow(dead_code))] // Used in renderer, but not for tests
     pub async fn drawing_mut(&self) -> MutexGuard<'_, DrawingState> {
         self.drawing.lock().await
     }

--- a/src/renderer_server/handlers/fill.rs
+++ b/src/renderer_server/handlers/fill.rs
@@ -4,7 +4,7 @@ use super::HandlerError;
 use super::super::{
     event_loop_notifier::EventLoopNotifier,
     app::{TurtleId, TurtleDrawings},
-    access_control::{AccessControl, RequiredData, RequiredTurtles},
+    access_control::AccessControl,
     renderer::display_list::DisplayList,
 };
 
@@ -15,13 +15,10 @@ pub(crate) async fn begin_fill(
     event_loop: EventLoopNotifier,
     id: TurtleId,
 ) -> Result<(), HandlerError> {
-    let mut data = app_control.get(RequiredData {
-        drawing: false,
-        turtles: Some(RequiredTurtles::One(id)),
-    }, data_req_queued).await;
-    let mut turtles = data.turtles_mut().await;
+    let turtle = app_control.get(id, data_req_queued).await;
+    let mut turtle = turtle.lock().await;
 
-    let TurtleDrawings {state: turtle, drawings, current_fill_polygon} = turtles.one_mut();
+    let TurtleDrawings {state: turtle, drawings, current_fill_polygon} = &mut *turtle;
 
     // Ignore the request if we are already filling
     if current_fill_polygon.is_some() {
@@ -43,13 +40,10 @@ pub(crate) async fn end_fill(
     app_control: &AccessControl,
     id: TurtleId,
 ) -> Result<(), HandlerError> {
-    let mut data = app_control.get(RequiredData {
-        drawing: false,
-        turtles: Some(RequiredTurtles::One(id)),
-    }, data_req_queued).await;
-    let mut turtles = data.turtles_mut().await;
+    let turtle = app_control.get(id, data_req_queued).await;
+    let mut turtle = turtle.lock().await;
 
-    let TurtleDrawings {current_fill_polygon, ..} = turtles.one_mut();
+    let TurtleDrawings {current_fill_polygon, ..} = &mut *turtle;
 
     // No need to add the turtle's current position to the polygon since it should already be there
 

--- a/src/renderer_server/handlers/turtle_prop.rs
+++ b/src/renderer_server/handlers/turtle_prop.rs
@@ -14,7 +14,7 @@ use super::super::{
     event_loop_notifier::EventLoopNotifier,
     state::{self, TurtleState},
     app::{TurtleId, TurtleDrawings},
-    access_control::{AccessControl, RequiredData, RequiredTurtles},
+    access_control::AccessControl,
     renderer::display_list::DisplayList,
 };
 
@@ -25,13 +25,10 @@ pub(crate) async fn turtle_prop(
     id: TurtleId,
     prop: TurtleProp,
 ) -> Result<(), HandlerError> {
-    let mut data = app_control.get(RequiredData {
-        drawing: false,
-        turtles: Some(RequiredTurtles::One(id)),
-    }, data_req_queued).await;
-    let mut turtles = data.turtles_mut().await;
+    let turtle = app_control.get(id, data_req_queued).await;
+    let turtle = turtle.lock().await;
 
-    let TurtleDrawings {state: turtle, current_fill_polygon, ..} = turtles.one_mut();
+    let TurtleDrawings {state: turtle, current_fill_polygon, ..} = &*turtle;
 
     use TurtleProp::*;
     use PenProp::*;
@@ -62,13 +59,10 @@ pub(crate) async fn set_turtle_prop(
     id: TurtleId,
     prop_value: TurtlePropValue,
 ) -> Result<(), HandlerError> {
-    let mut data = app_control.get(RequiredData {
-        drawing: false,
-        turtles: Some(RequiredTurtles::One(id)),
-    }, data_req_queued).await;
-    let mut turtles = data.turtles_mut().await;
+    let turtle = app_control.get(id, data_req_queued).await;
+    let mut turtle = turtle.lock().await;
 
-    let TurtleDrawings {state: turtle, current_fill_polygon, ..} = turtles.one_mut();
+    let TurtleDrawings {state: turtle, current_fill_polygon, ..} = &mut *turtle;
 
     use TurtlePropValue::*;
     use PenPropValue::*;
@@ -117,13 +111,10 @@ pub(crate) async fn reset_turtle_prop(
     id: TurtleId,
     prop: TurtleProp,
 ) -> Result<(), HandlerError> {
-    let mut data = app_control.get(RequiredData {
-        drawing: false,
-        turtles: Some(RequiredTurtles::One(id)),
-    }, data_req_queued).await;
-    let mut turtles = data.turtles_mut().await;
+    let turtle = app_control.get(id, data_req_queued).await;
+    let mut turtle = turtle.lock().await;
 
-    let TurtleDrawings {state: turtle, current_fill_polygon, ..} = turtles.one_mut();
+    let TurtleDrawings {state: turtle, current_fill_polygon, ..} = &mut *turtle;
 
     let mut drawing_changed = false;
 
@@ -189,13 +180,10 @@ pub(crate) async fn reset_turtle(
     event_loop: EventLoopNotifier,
     id: TurtleId,
 ) -> Result<(), HandlerError> {
-    let mut data = app_control.get(RequiredData {
-        drawing: false,
-        turtles: Some(RequiredTurtles::One(id)),
-    }, data_req_queued).await;
-    let mut turtles = data.turtles_mut().await;
+    let turtle = app_control.get(id, data_req_queued).await;
+    let mut turtle = turtle.lock().await;
 
-    let TurtleDrawings {state: turtle, current_fill_polygon, ..} = turtles.one_mut();
+    let TurtleDrawings {state: turtle, current_fill_polygon, ..} = &mut *turtle;
 
     *turtle = TurtleState::default();
 


### PR DESCRIPTION
This PR rewrites `AccessControl` as a data structure that does not require any internal Tokio tasks to manage the state of the turtles and drawing. It is a radically simplified version of the previous `AccessControl` type that accomplishes all of the same goals. It also splits the code between multiple files, hopefully making it a bit easier to read and understand.

The existing version of `AccessControl` was focused on correctness and figuring out how to implement the right behaviour. That's why it used a separate task to represent each resource and channels to communicate with that resource. While that mental model is correct and easy to understand, doing a ton of async communication where a boolean would also suffice is very wasteful. 

This version builds on that work and creates a simple data structure that is both correct and performant. The current status of each resource is kept using a single boolean. A queue of pending requests is only utilized if the resource is not already available. The common case where each request only needs a single resource is now very fast. There are far fewer steps between requesting a resource and getting access to it, especially if that resource is already available.

The API is now fully type-safe and driven by generics and traits. Many of the runtime checks that were previously necessary are now completely gone. For example, consider the following code from one of our handlers:

```rust
let mut data = app_control.get(RequiredData {
    drawing: false,
    turtles: Some(RequiredTurtles::One(id)),
}, data_req_queued).await;
let mut turtles = data.turtles_mut().await;

let TurtleDrawings {state: turtle, current_fill_polygon, ..} = turtles.one_mut();
```

This requests access to a single turtle. The API however doesn't know how much you're requesting, so you're forced to pretend like there could be many turtles (e.g. `turtles_mut()`). You're then forced to assert that only a single turtle was returned (e.g. `one_mut()`) even though you already know that to be the case. This is very error prone and easy to mess up.

The new API looks as follows:

```rust
let turtle = app_control.get(id, data_req_queued).await;
let turtle = turtle.lock().await;
let TurtleDrawings {state: turtle, current_fill_polygon, ..} = &*turtle;
```

Here, we use the type system (generics and traits) to encode that only a single turtle is requested and only a single turtle will be returned. Even the code inside `get` is simplified and you no longer need to even check if the drawing was requested in cases when it isn't. No runtime checks are required because the API knows exactly what you are going to get back.
