### PR TITLE
WIP: Automagic number converting

### DIFF
--- a/examples/square.rs
+++ b/examples/square.rs
@@ -1,10 +1,24 @@
 use turtle::Turtle;
 
+struct MyCoord {
+    x: u8,
+}
+
+impl From<MyCoord> for f64 {
+    fn from(source: MyCoord) -> Self {
+        f64::from(source.x)
+    }
+}
+
 fn main() {
     let mut turtle = Turtle::new();
 
-    for _ in 0..4 {
-        turtle.forward(200.0);
-        turtle.right(90.0);
-    }
+    turtle.forward(200);
+    turtle.right(90);
+    turtle.forward(200u8);
+    turtle.right(90f32);
+    turtle.forward(200.0);
+    turtle.right(90.0);
+    turtle.forward(MyCoord { x: 200 });
+    turtle.right(MyCoord { x: 90 });
 }

--- a/src/async_turtle.rs
+++ b/src/async_turtle.rs
@@ -71,7 +71,11 @@ impl AsyncTurtle {
         Self {client, id, angle_unit}
     }
 
-    pub async fn forward(&mut self, distance: Distance) {
+    pub async fn forward<T>(&mut self, distance: T)
+    where
+        f64: From<T>,
+    {
+        let distance = f64::from(distance);
         self.client.move_forward(self.id, distance).await
     }
 
@@ -80,7 +84,11 @@ impl AsyncTurtle {
         self.client.move_forward(self.id, -distance).await
     }
 
-    pub async fn right(&mut self, angle: Angle) {
+    pub async fn right<Angle>(&mut self, angle: Angle)
+    where
+        f64: From<Angle>,
+    {
+        let angle = f64::from(angle);
         let angle = self.angle_unit.to_radians(angle);
         self.client.rotate_in_place(self.id, angle, RotationDirection::Clockwise).await
     }

--- a/src/turtle.rs
+++ b/src/turtle.rs
@@ -90,7 +90,10 @@ impl Turtle {
     /// turtle.forward(-223.0);
     /// # assert_eq!(turtle.position().y.round(), -113.0);
     /// ```
-    pub fn forward(&mut self, distance: Distance) {
+    pub fn forward<Distance>(&mut self, distance: Distance)
+    where
+        f64: From<Distance>,
+    {
         block_on(self.turtle.forward(distance))
     }
 
@@ -154,7 +157,10 @@ impl Turtle {
     /// # let expected = (expected * 1e5).trunc();
     /// # assert_eq!((turtle.heading() * 1e5).trunc(), expected);
     /// ```
-    pub fn right(&mut self, angle: Angle) {
+    pub fn right<Angle>(&mut self, angle: Angle)
+    where
+        f64: From<Angle>,
+    {
         block_on(self.turtle.right(angle))
     }
 


### PR DESCRIPTION
It bothers me a lot that you always have to write `t.forward(100.0)` instead of `t.forward(100)`.

It turns out to be quite straight forward to make the argument type variable as long as it can be converted to f64 using the `From` trait.

A sample function would be:

```rust
pub type Distance = f64;

fn multiply<T>(x:T) -> Distance where Distance: From<T> {
    let n:Distance = Distance::from(x);
    n*n
}

fn main() {
println!("{:?}", multiply(5));
println!("{:?}", multiply(6.0));
println!("{:?}", multiply(7.3));
println!("{:?}", multiply(244u8));
}
```
Playground: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=11144955d3f2b0ae26e924612f905dd9

This PR contains a **proof of concept** implementation for the square example demonstrating different types as argument to `forward` and `right` including a custom `struct` that implements `impl From<CustomStruct> for f64`. 

Would you appreciate that kind of change? Should I convert the whole turtle code base?