### PR TITLE
Replaced the trait method calls for lerp() with fully qualified calls…

### DIFF
--- a/src/point.rs
+++ b/src/point.rs
@@ -334,8 +334,8 @@ impl Lerp for Point {
     #[inline(always)]
     fn lerp(&self, other: &Self, scalar: &Self::Scalar) -> Self {
         Self {
-            x: self.x.lerp(&other.x, &scalar),
-            y: self.y.lerp(&other.y, &scalar),
+            x: Lerp::lerp(&self.x, &other.x, &scalar),
+            y: Lerp::lerp(&self.y, &other.y, &scalar),
         }
     }
 }

--- a/src/radians.rs
+++ b/src/radians.rs
@@ -81,7 +81,7 @@ impl Lerp for Radians {
 
     #[inline(always)]
     fn lerp(&self, other: &Self, scalar: &Self::Scalar) -> Self {
-        Radians(self.0.lerp(&other.0, &scalar))
+        Radians(Lerp::lerp(&self.0, &other.0, &scalar))
     }
 }
 


### PR DESCRIPTION
… to prevent unstable Rust-Std library features to be used.